### PR TITLE
Adding stringPage scaffolds

### DIFF
--- a/src/main/scaffolds/stringPage/app/controllers/$className$Controller.scala
+++ b/src/main/scaffolds/stringPage/app/controllers/$className$Controller.scala
@@ -1,0 +1,47 @@
+package controllers
+
+import javax.inject.Inject
+
+import play.api.data.Form
+import play.api.i18n.{I18nSupport, MessagesApi}
+import uk.gov.hmrc.play.bootstrap.controller.FrontendController
+import connectors.DataCacheConnector
+import controllers.actions._
+import config.FrontendAppConfig
+import forms.$className$Form
+import identifiers.$className$Id
+import models.Mode
+import utils.{Navigator, UserAnswers}
+import views.html.$className;format="decap"$
+
+import scala.concurrent.Future
+
+class $className$Controller @Inject()(
+                                        appConfig: FrontendAppConfig,
+                                        override val messagesApi: MessagesApi,
+                                        dataCacheConnector: DataCacheConnector,
+                                        navigator: Navigator,
+                                        authenticate: AuthAction,
+                                        getData: DataRetrievalAction,
+                                        requireData: DataRequiredAction) extends FrontendController with I18nSupport {
+
+  def onPageLoad(mode: Mode) = (authenticate andThen getData andThen requireData) {
+    implicit request =>
+      val preparedForm = request.userAnswers.$className;format="decap"$ match {
+        case None => $className$Form()
+        case Some(value) => $className$Form().fill(value)
+      }
+      Ok($className;format="decap"$(appConfig, preparedForm, mode))
+  }
+
+  def onSubmit(mode: Mode) = (authenticate andThen getData andThen requireData).async {
+    implicit request =>
+      $className$Form().bindFromRequest().fold(
+        (formWithErrors: Form[_]) =>
+          Future.successful(BadRequest($className;format="decap"$(appConfig, formWithErrors, mode))),
+        (value) =>
+          dataCacheConnector.save[String](request.externalId, $className$Id.toString, value).map(cacheMap =>
+            Redirect(navigator.nextPage($className$Id, mode)(new UserAnswers(cacheMap))))
+      )
+  }
+}

--- a/src/main/scaffolds/stringPage/app/forms/$className$Form.scala
+++ b/src/main/scaffolds/stringPage/app/forms/$className$Form.scala
@@ -1,0 +1,25 @@
+package forms
+
+import play.api.data.{Form, FormError}
+import play.api.data.Forms._
+import play.api.data.format.Formatter
+
+object $className$Form extends FormErrorHelper {
+
+  private val errorKeyBlank = "error.required"
+
+  def $className;format="decap"$Formatter() = new Formatter[String] {
+
+    def bind(key: String, data: Map[String, String]) = {
+      data.get(key) match {
+        case None => produceError(key, errorKeyBlank)
+        case Some("") => produceError(key, errorKeyBlank)
+        case Some(s) => Right(s)
+      }
+    }
+
+    def unbind(key: String, value: String) = Map(key -> value)
+  }
+
+  def apply(): Form[String] = Form(single("value" -> of($className;format="decap"$Formatter(errorKeyBlank))))
+}

--- a/src/main/scaffolds/stringPage/app/identifiers/$className$Id.scala
+++ b/src/main/scaffolds/stringPage/app/identifiers/$className$Id.scala
@@ -1,0 +1,5 @@
+package identifiers
+
+case object $className$Id extends Identifier {
+  override def toString: String = "$className;format="decap"$"
+}

--- a/src/main/scaffolds/stringPage/app/views/$className__decap$.scala.html
+++ b/src/main/scaffolds/stringPage/app/views/$className__decap$.scala.html
@@ -1,0 +1,26 @@
+@import config.FrontendAppConfig
+@import uk.gov.hmrc.play.views.html._
+@import controllers.routes._
+@import models.Mode
+@import viewmodels.InputViewModel
+
+@(appConfig: FrontendAppConfig, form: Form[_], mode: Mode)(implicit request: Request[_], messages: Messages)
+
+@main_template(
+    title = messages("$className;format="decap"$.title"),
+    appConfig = appConfig,
+    bodyClasses = None) {
+
+    @helpers.form(action = $className$Controller.onSubmit(mode), 'autoComplete -> "off") {
+
+        @components.back_link()
+
+        @components.error_summary(form.errors)
+
+        @components.heading("$className;format="decap"$.heading")
+
+        @components.input_text(InputViewModel("value", form), label = messages("$className;format="decap"$.heading"), labelClass=Some("visually-hidden"))
+
+        @components.submit_button()
+    }
+}

--- a/src/main/scaffolds/stringPage/default.properties
+++ b/src/main/scaffolds/stringPage/default.properties
@@ -1,0 +1,2 @@
+description = Generates a controller and view for a page with a single string question
+className = MyNewPage

--- a/src/main/scaffolds/stringPage/generated-test/controllers/$className$ControllerSpec.scala
+++ b/src/main/scaffolds/stringPage/generated-test/controllers/$className$ControllerSpec.scala
@@ -1,0 +1,79 @@
+package controllers
+
+import play.api.data.Form
+import play.api.libs.json.JsString
+import uk.gov.hmrc.http.cache.client.CacheMap
+import utils.FakeNavigator
+import connectors.FakeDataCacheConnector
+import controllers.actions._
+import play.api.test.Helpers._
+import forms.$className$Form
+import identifiers.$className$Id
+import models.NormalMode
+import views.html.$className;format="decap"$
+
+class $className$ControllerSpec extends ControllerSpecBase {
+
+  def onwardRoute = routes.IndexController.onPageLoad()
+
+  def controller(dataRetrievalAction: DataRetrievalAction = getEmptyCacheMap) =
+    new $className$Controller(frontendAppConfig, messagesApi, FakeDataCacheConnector, new FakeNavigator(desiredRoute = onwardRoute), FakeAuthAction,
+      dataRetrievalAction, new DataRequiredActionImpl)
+
+  def viewAsString(form: Form[_] = $className$Form()) = $className;format="decap"$(frontendAppConfig, form, NormalMode)(fakeRequest, messages).toString
+
+  val testAnswer = "answer"
+
+  "$className$ Controller" must {
+
+    "return OK and the correct view for a GET" in {
+      val result = controller().onPageLoad(NormalMode)(fakeRequest)
+
+      status(result) mustBe OK
+      contentAsString(result) mustBe viewAsString()
+    }
+
+    "populate the view correctly on a GET when the question has previously been answered" in {
+      val validData = Map($className$Id.toString -> JsString(testAnswer))
+      val getRelevantData = new FakeDataRetrievalAction(Some(CacheMap(cacheMapId, validData)))
+
+      val result = controller(getRelevantData).onPageLoad(NormalMode)(fakeRequest)
+
+      contentAsString(result) mustBe viewAsString($className$Form().fill(testAnswer))
+    }
+
+    "redirect to the next page when valid data is submitted" in {
+      val postRequest = fakeRequest.withFormUrlEncodedBody(("value", testAnswer))
+
+      val result = controller().onSubmit(NormalMode)(postRequest)
+
+      status(result) mustBe SEE_OTHER
+      redirectLocation(result) mustBe Some(onwardRoute.url)
+    }
+
+    "return a Bad Request and errors when invalid data is submitted" in {
+      val postRequest = fakeRequest.withFormUrlEncodedBody(("value", ""))
+      val boundForm = $className$Form().bind(Map("value" -> ""))
+
+      val result = controller().onSubmit(NormalMode)(postRequest)
+
+      status(result) mustBe BAD_REQUEST
+      contentAsString(result) mustBe viewAsString(boundForm)
+    }
+
+    "redirect to Session Expired for a GET if no existing data is found" in {
+      val result = controller(dontGetAnyData).onPageLoad(NormalMode)(fakeRequest)
+
+      status(result) mustBe SEE_OTHER
+      redirectLocation(result) mustBe Some(routes.SessionExpiredController.onPageLoad().url)
+    }
+
+    "redirect to Session Expired for a POST if no existing data is found" in {
+      val postRequest = fakeRequest.withFormUrlEncodedBody(("value", testAnswer))
+      val result = controller(dontGetAnyData).onSubmit(NormalMode)(postRequest)
+
+      status(result) mustBe SEE_OTHER
+      redirectLocation(result) mustBe Some(routes.SessionExpiredController.onPageLoad().url)
+    }
+  }
+}

--- a/src/main/scaffolds/stringPage/generated-test/forms/$className$FormSpec.scala
+++ b/src/main/scaffolds/stringPage/generated-test/forms/$className$FormSpec.scala
@@ -1,0 +1,24 @@
+package forms
+
+class $className$FormSpec extends FormSpec {
+
+  val errorKeyBlank = "blank"
+
+  "$className$ Form" must {
+
+    "bind a string" in {
+      val form = $className$Form(errorKeyBlank).bind(Map("value" -> "answer"))
+      form.get shouldBe "answer"
+    }
+
+    "fail to bind a blank value" in {
+      val expectedError = error("value", errorKeyBlank)
+      checkForError($className$Form(errorKeyBlank), Map("value" -> ""), expectedError)
+    }
+
+    "fail to bind when value is omitted" in {
+      val expectedError = error("value", errorKeyBlank)
+      checkForError($className$Form(errorKeyBlank), emptyForm, expectedError)
+    }
+  }
+}

--- a/src/main/scaffolds/stringPage/generated-test/views/$className$ViewSpec.scala
+++ b/src/main/scaffolds/stringPage/generated-test/views/$className$ViewSpec.scala
@@ -1,0 +1,27 @@
+package views
+
+import play.api.data.Form
+import controllers.routes
+import forms.$className$Form
+import models.NormalMode
+import views.behaviours.StringViewBehaviours
+import views.html.$className;format="decap"$
+
+class $className$ViewSpec extends StringViewBehaviours {
+
+  val messageKeyPrefix = "$className;format="decap"$"
+
+  def createView = () => $className;format="decap"$(frontendAppConfig, $className$Form(), NormalMode)(fakeRequest, messages)
+
+  def createViewUsingForm = (form: Form[String]) => $className;format="decap"$(frontendAppConfig, form, NormalMode)(fakeRequest, messages)
+
+  val form = $className$Form()
+
+  "$className$ view" must {
+    behave like normalPage(createView, messageKeyPrefix)
+
+    behave like pageWithBackLink(createView)
+
+    behave like stringPage(createViewUsingForm, messageKeyPrefix, routes.$className$Controller.onSubmit(NormalMode).url)
+  }
+}

--- a/src/main/scaffolds/stringPage/migrations/$className__snake$.sh
+++ b/src/main/scaffolds/stringPage/migrations/$className__snake$.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+echo "Applying migration $className;format="snake"$"
+
+echo "Adding routes to conf/app.routes"
+
+echo "" >> ../conf/app.routes
+echo "GET        /$className;format="decap"$               controllers.$className$Controller.onPageLoad(mode: Mode = NormalMode)" >> ../conf/app.routes
+echo "POST       /$className;format="decap"$               controllers.$className$Controller.onSubmit(mode: Mode = NormalMode)" >> ../conf/app.routes
+
+echo "GET        /change$className$                        controllers.$className$Controller.onPageLoad(mode: Mode = CheckMode)" >> ../conf/app.routes
+echo "POST       /change$className$                        controllers.$className$Controller.onSubmit(mode: Mode = CheckMode)" >> ../conf/app.routes
+
+echo "Adding messages to conf.messages"
+echo "" >> ../conf/messages.en
+echo "$className;format="decap"$.title = $className;format="decap"$" >> ../conf/messages.en
+echo "$className;format="decap"$.heading = $className;format="decap"$" >> ../conf/messages.en
+echo "$className;format="decap"$.checkYourAnswersLabel = $className;format="decap"$" >> ../conf/messages.en
+
+echo "Adding helper line into UserAnswers"
+awk '/class/ {\
+     print;\
+     print "  def $className;format="decap"$: Option[String] = cacheMap.getEntry[String]($className$Id.toString)";\
+     print "";\
+     next }1' ../app/utils/UserAnswers.scala > tmp && mv tmp ../app/utils/UserAnswers.scala
+
+echo "Adding helper method to CheckYourAnswersHelper"
+awk '/class/ {\
+     print;\
+     print "";\
+     print "  def $className;format="decap"$: Option[AnswerRow] = userAnswers.$className;format="decap"$ map {";\
+     print "    x => AnswerRow(\"$className;format="decap"$.checkYourAnswersLabel\", s\"\$x\", false, routes.$className$Controller.onPageLoad(CheckMode).url)";\
+     print "  }";\
+     next }1' ../app/utils/CheckYourAnswersHelper.scala > tmp && mv tmp ../app/utils/CheckYourAnswersHelper.scala
+
+echo "Moving test files from generated-test/ to test/"
+rsync -avm --include='*.scala' -f 'hide,! */' ../generated-test/ ../test/
+rm -rf ../generated-test/
+
+echo "Migration $className;format="snake"$ completed"


### PR DESCRIPTION
# Adding stringPage scaffolds

**New Feature**

This is an addition of a scaffold for a page with a single input like "What is your full name?". It will have a single H1 and no visible label on the page.

This doesnt contain the constraints style validation as has been discussed but this can (and probably should) be added later in a seperate PR

## Checklist

* [x] I've included appropriate unit tests with any code I've added
* [x] I've tested by creating a new service from my fork, applying any scaffolds I've changed, and checking that all unit tests pass and the service runs as expected
* [x] I've added my code using logical, atomic commits
