### PR TITLE
Added behaviours for error keys and max lengths

### DIFF
--- a/src/main/g8/test/forms/behaviours/FormBehaviours.scala
+++ b/src/main/g8/test/forms/behaviours/FormBehaviours.scala
@@ -55,6 +55,34 @@ trait FormBehaviours extends FormSpec {
       checkForError(form, data, expectedError)
     }
   }
+  
+  def formWithMaxLengthTextFields(fields: MaxLengthField*) = {
+    for (field <- fields) {
+      s"fail to bind when ${field.fieldName} has more characters than ${field.maxLength}" in {
+        val invalid = "A" * (field.maxLength + 1)
+        val validFields = validData - field.fieldName
+        val data = validFields ++ Map(field.fieldName -> invalid)
+        val expectedError = error(field.fieldName, field.errorMessageKey, field.maxLength)
+        checkForError(form, data, expectedError)
+      }
+    }
+  }
+
+  def formWithMandatoryTextFieldsAndCustomKey(fields: (String, String)*) = {
+    for ((key, errorMessage) <- fields) {
+      s"fail to bind when $key is omitted" in {
+        val data = validData - key + (key -> "")
+        val expectedError = error(key, errorMessage)
+        checkForError(form, data, expectedError)
+      }
+
+      s"fail to bind when $key is blank" in {
+        val data = validData + (key -> "")
+        val expectedError = error(key, errorMessage)
+        checkForError(form, data, expectedError)
+      }
+    }
+  }
 
   def formWithBooleans(fields: String*) = {
     for (field <- fields) {

--- a/src/main/g8/test/models/MaxLengthField.scala
+++ b/src/main/g8/test/models/MaxLengthField.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+case class MaxLengthField(fieldName: String, errorMessageKey: String, maxLength: Int)


### PR DESCRIPTION
**New feature** 
- The addition of a behaviour that allows for testing a mandatory field with a custom error key
- The addition of a form behaviour that tests for a x amount of fields with a maximum length validation requirement.
- The addition of a MaxLengthField case class that allows the new form behaviour to be more readable and usable.

## Checklist

* [x] I've included appropriate unit tests with any code I've added
* [ ] I've tested by creating a new service from my fork, applying any scaffolds I've changed, and checking that all unit tests pass and the service runs as expected
* [ ] I've added my code using logical, atomic commits
