### PR TITLE
Updated mandatory behaviour for error keys and added max lengths

### DIFF
--- a/src/main/g8/test/forms/behaviours/FormBehaviours.scala
+++ b/src/main/g8/test/forms/behaviours/FormBehaviours.scala
@@ -2,6 +2,7 @@ package forms.behaviours
 
 import play.api.data.Form
 import forms.FormSpec
+import models.{MandatoryField, MaxLengthField}
 
 trait FormBehaviours extends FormSpec {
 
@@ -26,17 +27,28 @@ trait FormBehaviours extends FormSpec {
     }
   }
 
-  def formWithMandatoryTextFields(fields: String*) = {
+  def formWithMaxLengthTextFields(fields: MaxLengthField*) = {
     for (field <- fields) {
-      s"fail to bind when \$field is omitted" in {
-        val data = validData - field
-        val expectedError = error(field, "error.required")
+      s"fail to bind when \${field.fieldName} has more characters than \${field.maxLength}" in {
+        val invalid = "A" * (field.maxLength + 1)
+        val data = validData + (field.fieldName -> invalid)
+        val expectedError = error(field.fieldName, field.errorMessageKey, field.maxLength)
+        checkForError(form, data, expectedError)
+      }
+    }
+  }
+
+  def formWithMandatoryTextFields(fields: MandatoryField*) = {
+    for (field <- fields) {
+      s"fail to bind when \${field.fieldName} is omitted" in {
+        val data = validData - field.fieldName
+        val expectedError = error(field.fieldName, field.errorMessageKey)
         checkForError(form, data, expectedError)
       }
 
-      s"fail to bind when \$field is blank" in {
-        val data = validData + (field -> "")
-        val expectedError = error(field, "error.required")
+      s"fail to bind when \${field.fieldName} is blank" in {
+        val data = validData + (field.fieldName -> "")
+        val expectedError = error(field.fieldName, field.errorMessageKey)
         checkForError(form, data, expectedError)
       }
     }

--- a/src/main/g8/test/models/MandatoryField.scala
+++ b/src/main/g8/test/models/MandatoryField.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+case class MandatoryField(fieldName: String, errorMessageKey: String = "error.required")

--- a/src/main/g8/test/models/MaxLengthField.scala
+++ b/src/main/g8/test/models/MaxLengthField.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+case class MaxLengthField(fieldName: String, errorMessageKey: String, maxLength: Int)

--- a/src/main/scaffolds/questionPage/generated-test/forms/$className$FormSpec.scala
+++ b/src/main/scaffolds/questionPage/generated-test/forms/$className$FormSpec.scala
@@ -1,7 +1,7 @@
 package forms
 
 import forms.behaviours.FormBehaviours
-import models.$className$
+import models.{$className$, MandatoryField}
 
 class $className$FormSpec extends FormBehaviours {
 
@@ -15,6 +15,9 @@ class $className$FormSpec extends FormBehaviours {
   "$className$ form" must {
     behave like questionForm($className$("value 1", "value 2"))
 
-    behave like formWithMandatoryTextFields("field1", "field2")
+    behave like formWithMandatoryTextFields(
+      MandatoryField("field1"),
+      MandatoryField("field2")
+    )
   }
 }


### PR DESCRIPTION
# Updated mandatory behaviour for error keys and added max lengths

**New feature**
- Case classes for mandatory fields and max length fields
- Updated mandatory field behaviour to be able to take optional error message keys
- Added behaviour to test for fields with max lengths

## Checklist
* [ ] I've tested by creating a new service from my fork, applying any scaffolds I've changed, and checking that all unit tests pass and the service runs as expected
* [x] I've added my code using logical, atomic commits
