### PR TITLE
Fix hardcoded name and imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
+## v0.4.1 - 2017-12-21
+
+### Fixed
+* Hardcoded name in options model
+* Unnecessary imports
+
 ## v0.4.0 - 2017-12-21
 
 ### Changed

--- a/src/main/g8/project/build.properties
+++ b/src/main/g8/project/build.properties
@@ -1,2 +1,2 @@
 sbt.version=0.13.15
-hmrc-frontend-scaffold.version=0.4.0
+hmrc-frontend-scaffold.version=0.4.1

--- a/src/main/scaffolds/optionsPage/app/models/$className$.scala
+++ b/src/main/scaffolds/optionsPage/app/models/$className$.scala
@@ -15,7 +15,7 @@ object $className$ {
 
   val options: Set[RadioOption] = values.map {
     value =>
-      RadioOption("myOptionsPage", value.toString)
+      RadioOption("$className;format="decap"$", value.toString)
   }
 
   implicit val enumerable: Enumerable[$className$] =

--- a/src/main/scaffolds/page/app/controllers/$className$Controller.scala
+++ b/src/main/scaffolds/page/app/controllers/$className$Controller.scala
@@ -2,15 +2,10 @@ package controllers
 
 import javax.inject.Inject
 
-import play.api.data.Form
 import play.api.i18n.{I18nSupport, MessagesApi}
 import uk.gov.hmrc.play.bootstrap.controller.FrontendController
-import connectors.DataCacheConnector
 import controllers.actions._
 import config.FrontendAppConfig
-import forms.BooleanForm
-import models.Mode
-import utils.{Navigator, UserAnswers}
 import views.html.$className;format="decap"$
 
 import scala.concurrent.Future

--- a/src/main/scaffolds/page/app/views/$className__decap$.scala.html
+++ b/src/main/scaffolds/page/app/views/$className__decap$.scala.html
@@ -1,8 +1,4 @@
 @import config.FrontendAppConfig
-@import uk.gov.hmrc.play.views.html._
-@import controllers.routes._
-@import models.Mode
-@import utils.FormHelpers
 
 @(appConfig: FrontendAppConfig)(implicit request: Request[_], messages: Messages)
 

--- a/src/main/scaffolds/page/generated-test/controllers/$className$ControllerSpec.scala
+++ b/src/main/scaffolds/page/generated-test/controllers/$className$ControllerSpec.scala
@@ -1,14 +1,7 @@
 package controllers
 
-import play.api.data.Form
-import play.api.libs.json.JsBoolean
-import uk.gov.hmrc.http.cache.client.CacheMap
-import utils.FakeNavigator
-import connectors.FakeDataCacheConnector
 import controllers.actions._
 import play.api.test.Helpers._
-import forms.BooleanForm
-import models.NormalMode
 import views.html.$className;format="decap"$
 
 class $className$ControllerSpec extends ControllerSpecBase {

--- a/src/main/scaffolds/page/generated-test/views/$className$ViewSpec.scala
+++ b/src/main/scaffolds/page/generated-test/views/$className$ViewSpec.scala
@@ -1,13 +1,9 @@
 package views
 
-import play.api.data.Form
-import controllers.routes
-import forms.BooleanForm
-import views.behaviours.YesNoViewBehaviours
-import models.NormalMode
+import views.behaviours.ViewBehaviours
 import views.html.$className;format="decap"$
 
-class $className$ViewSpec extends YesNoViewBehaviours {
+class $className$ViewSpec extends ViewBehaviours {
 
   val messageKeyPrefix = "$className;format="decap"$"
 


### PR DESCRIPTION
# Fix hardcoded name and imports

Removed some unneeded imports from the page scaffold, and a hardcoded name from the options page scaffold.

## Checklist

* [x] I've tested by creating a new service from my fork, applying any scaffolds I've changed, and checking that all unit tests pass and the service runs as expected
* [x] I've added my code using logical, atomic commits