### PR TITLE
Use property testing for int forms

### DIFF
--- a/src/main/g8/app/forms/mappings/Constraints.scala
+++ b/src/main/g8/app/forms/mappings/Constraints.scala
@@ -39,6 +39,19 @@ trait Constraints {
         }
     }
 
+  protected def inRange[A](minimum: A, maximum: A, errorKey: String)(implicit ev: Ordering[A]): Constraint[A] =
+    Constraint {
+      input =>
+        
+        import ev._
+        
+        if (input >= minimum && input <= maximum) {
+          Valid
+        } else {
+          Invalid(errorKey, minimum, maximum)
+        }
+    }
+    
   protected def regexp(regex: String, errorKey: String): Constraint[String] =
     Constraint {
       case str if str.matches(regex) =>

--- a/src/main/g8/app/forms/mappings/Formatters.scala
+++ b/src/main/g8/app/forms/mappings/Formatters.scala
@@ -40,7 +40,7 @@ trait Formatters {
   private[mappings] def intFormatter(requiredKey: String, wholeNumberKey: String, nonNumericKey: String): Formatter[Int] =
     new Formatter[Int] {
 
-      val decimalRegexp = """^(\d*\.\d*)\$"""
+      val decimalRegexp = """^-?(\d*\.\d*)\$"""
 
       private val baseFormatter = stringFormatter(requiredKey)
 

--- a/src/main/g8/project/FrontendBuild.scala
+++ b/src/main/g8/project/FrontendBuild.scala
@@ -28,6 +28,7 @@ private object AppDependencies {
   private val playConditionalFormMappingVersion = "0.2.0"
   private val playLanguageVersion = "3.4.0"
   private val bootstrapVersion = "1.0.0"
+  private val scalacheckVersion = "1.13.4"
 
   val compile = Seq(
     ws,
@@ -56,7 +57,8 @@ private object AppDependencies {
         "org.pegdown" % "pegdown" % pegdownVersion % scope,
         "org.jsoup" % "jsoup" % "1.10.3" % scope,
         "com.typesafe.play" %% "play-test" % PlayVersion.current % scope,
-        "org.mockito" % "mockito-all" % mockitoAllVersion % scope
+        "org.mockito" % "mockito-all" % mockitoAllVersion % scope,
+        "org.scalacheck" %% "scalacheck" % scalacheckVersion % scope
       )
     }.test
   }

--- a/src/main/g8/test/forms/FormSpec.scala
+++ b/src/main/g8/test/forms/FormSpec.scala
@@ -1,9 +1,9 @@
 package forms
 
+import org.scalatest.{Matchers, OptionValues, WordSpec}
 import play.api.data.{Form, FormError}
-import uk.gov.hmrc.play.test.UnitSpec
 
-trait FormSpec extends UnitSpec {
+trait FormSpec extends WordSpec with OptionValues with Matchers {
 
   def checkForError(form: Form[_], data: Map[String, String], expectedErrors: Seq[FormError]) = {
     

--- a/src/main/g8/test/forms/behaviours/FieldBehaviours.scala
+++ b/src/main/g8/test/forms/behaviours/FieldBehaviours.scala
@@ -16,7 +16,7 @@ trait FieldBehaviours extends FormSpec with PropertyChecks with Generators {
 
       forAll(validDataGenerator -> "validDataItem") {
         dataItem: String =>
-          val result = form.bind(Map("value" -> dataItem)).apply(fieldName)
+          val result = form.bind(Map(fieldName -> dataItem)).apply(fieldName)
           result.value.value shouldBe dataItem
       }
     }

--- a/src/main/g8/test/forms/behaviours/FieldBehaviours.scala
+++ b/src/main/g8/test/forms/behaviours/FieldBehaviours.scala
@@ -1,0 +1,41 @@
+package forms.behaviours
+
+import forms.FormSpec
+import generators.Generators
+import org.scalacheck.Gen
+import org.scalatest.prop.PropertyChecks
+import play.api.data.{Form, FormError}
+
+trait FieldBehaviours extends FormSpec with PropertyChecks with Generators {
+
+  def fieldThatBindsValidData(form: Form[_],
+                              fieldName: String,
+                              validDataGenerator: Gen[String]): Unit = {
+
+    "bind valid data" in {
+
+      forAll(validDataGenerator -> "validDataItem") {
+        dataItem: String =>
+          val result = form.bind(Map("value" -> dataItem)).apply(fieldName)
+          result.value.value shouldBe dataItem
+      }
+    }
+  }
+
+  def mandatoryField(form: Form[_],
+                     fieldName: String,
+                     requiredError: FormError): Unit = {
+
+    "not bind when key is not present at all" in {
+
+      val result = form.bind(emptyForm).apply(fieldName)
+      result.errors shouldEqual Seq(requiredError)
+    }
+
+    "not bind blank values" in {
+
+      val result = form.bind(Map(fieldName -> "")).apply(fieldName)
+      result.errors shouldEqual Seq(requiredError)
+    }
+  }
+}

--- a/src/main/g8/test/forms/behaviours/IntFieldBehaviours.scala
+++ b/src/main/g8/test/forms/behaviours/IntFieldBehaviours.scala
@@ -1,0 +1,94 @@
+package forms.behaviours
+
+import play.api.data.{Form, FormError}
+
+trait IntFieldBehaviours extends FieldBehaviours {
+
+  def intField(form: Form[_],
+               fieldName: String,
+               nonNumericError: FormError,
+               wholeNumberError: FormError): Unit = {
+
+    "not bind non-numeric numbers" in {
+
+      forAll(nonNumerics -> "nonNumeric") {
+        nonNumeric =>
+          val result = form.bind(Map(fieldName -> nonNumeric)).apply(fieldName)
+          result.errors shouldEqual Seq(nonNumericError)
+      }
+    }
+
+    "not bind decimals" in {
+
+      forAll(decimals -> "decimal") {
+        decimal =>
+          val result = form.bind(Map(fieldName -> decimal)).apply(fieldName)
+          result.errors shouldEqual Seq(wholeNumberError)
+      }
+    }
+
+    "not bind integers larger than Int.MaxValue" in {
+
+      forAll(intsLargerThanMaxValue -> "massiveInt") {
+        num: BigInt =>
+          val result = form.bind(Map(fieldName -> num.toString)).apply(fieldName)
+          result.errors shouldEqual Seq(nonNumericError)
+      }
+    }
+
+    "not bind integers smaller than Int.MinValue" in {
+
+      forAll(intsSmallerThanMinValue -> "massivelySmallInt") {
+        num: BigInt =>
+          val result = form.bind(Map(fieldName -> num.toString)).apply(fieldName)
+          result.errors shouldEqual Seq(nonNumericError)
+      }
+    }
+  }
+
+  def intFieldWithMinimum(form: Form[_],
+                          fieldName: String,
+                          minimum: Int,
+                          expectedError: FormError): Unit = {
+
+    s"not bind integers below \$minimum" in {
+
+      forAll(intsBelowValue(minimum) -> "intBelowMin") {
+        number: Int =>
+          val result = form.bind(Map(fieldName -> number.toString)).apply(fieldName)
+          result.errors shouldEqual Seq(expectedError)
+      }
+    }
+  }
+  
+  def intFieldWithMaximum(form: Form[_],
+                          fieldName: String,
+                          maximum: Int,
+                          expectedError: FormError): Unit = {
+    
+    s"not bind integers above \$maximum" in {
+      
+      forAll(intsAboveValue(maximum) -> "intAboveMax") {
+        number: Int =>
+          val result = form.bind(Map(fieldName -> number.toString)).apply(fieldName)
+          result.errors shouldEqual Seq(expectedError)
+      }
+    }
+  }
+  
+  def intFieldWithRange(form: Form[_],
+                        fieldName: String,
+                        minimum: Int,
+                        maximum: Int,
+                        expectedError: FormError): Unit = {
+    
+    s"not bind integers outside the range \$minimum to \$maximum" in {
+      
+      forAll(intsOutsideRange(minimum, maximum) -> "intOutsideRange") {
+        number =>
+          val result = form.bind(Map(fieldName -> number.toString)).apply(fieldName)
+          result.errors shouldEqual Seq(expectedError)
+      }
+    }
+  }
+}

--- a/src/main/g8/test/generators/Generators.scala
+++ b/src/main/g8/test/generators/Generators.scala
@@ -1,0 +1,45 @@
+package generators
+
+import org.scalacheck.{Arbitrary, Gen, Shrink}
+import Gen._
+import Arbitrary._
+
+trait Generators {
+
+  implicit val dontShrink: Shrink[String] = Shrink.shrinkAny
+
+  def intersperse[A](a : List[A], b : List[A]): List[A] = a match {
+    case first :: rest => first :: intersperse(b, rest)
+    case _             => b
+  }
+
+  def intsInRangeWithCommas(min: Int, max: Int): Gen[String] = for {
+    number         <- choose[Int](min, max)
+    numberOfCommas <- choose(0, number.toString.length)
+    commas         <- listOfN(numberOfCommas, const(','))
+  } yield intersperse(number.toString.toList, commas).mkString
+
+  def intsLargerThanMaxValue: Gen[BigInt] =
+    arbitrary[BigInt] suchThat(x => x > Int.MaxValue)
+  
+  def intsSmallerThanMinValue: Gen[BigInt] =
+    arbitrary[BigInt] suchThat(x => x < Int.MinValue)
+
+  def nonNumerics: Gen[String] =
+    alphaStr suchThat(_.size > 0)
+
+  def decimals: Gen[String] =
+    arbitrary[BigDecimal]
+      .suchThat(_.abs < Int.MaxValue)
+      .suchThat(!_.isValidInt)
+      .map(_.formatted("%f"))
+
+  def intsBelowValue(value: Int): Gen[Int] =
+    arbitrary[Int] suchThat(_ < value)
+
+  def intsAboveValue(value: Int): Gen[Int] =
+    arbitrary[Int] suchThat(_ > value)
+
+  def intsOutsideRange(min: Int, max: Int): Gen[Int] =
+    arbitrary[Int] suchThat(x => x < min || x > max)
+}

--- a/src/main/scaffolds/intPage/app/forms/$className$FormProvider.scala
+++ b/src/main/scaffolds/intPage/app/forms/$className$FormProvider.scala
@@ -13,6 +13,6 @@ class $className$FormProvider @Inject() extends FormErrorHelper with Mappings {
         "$className;format="decap"$.error.required",
         "$className;format="decap"$.error.wholeNumber",
         "$className;format="decap"$.error.nonNumeric")
-          .verifying(minimumValue(0, "$className;format="decap"$.error.minimum"))
+          .verifying(inRange($minimum$, $maximum$, "$className;format="decap"$.error.outOfRange"))
     )
 }

--- a/src/main/scaffolds/intPage/default.properties
+++ b/src/main/scaffolds/intPage/default.properties
@@ -1,2 +1,4 @@
 description = Generates a controller and view for a page with a single integer question
 className = MyNewPage
+minimum = 0
+maximum = Int.MaxValue

--- a/src/main/scaffolds/intPage/generated-test/forms/$className$FormProviderSpec.scala
+++ b/src/main/scaffolds/intPage/generated-test/forms/$className$FormProviderSpec.scala
@@ -1,54 +1,46 @@
 package forms
 
-class $className$FormProviderSpec extends FormSpec {
+import forms.behaviours.IntFieldBehaviours
+import play.api.data.FormError
 
-  val errorKeyBlank = "$className;format="decap"$.error.required"
-  val errorKeyDecimal = "$className;format="decap"$.error.wholeNumber"
-  val errorKeyNonNumeric = "$className;format="decap"$.error.nonNumeric"
-  val errorKeyMinimum = "$className;format="decap"$.error.minimum"
+class $className$FormProviderSpec extends IntFieldBehaviours {
 
-  "$className$ Form" must {
+  val form = new $className$FormProvider()()
 
-    val formProvider = new $className$FormProvider()
+  ".value" must {
 
-    "bind zero" in {
-      val form = formProvider().bind(Map("value" -> "0"))
-      form.get shouldBe 0
-    }
+    val fieldName = "value"
 
-    "bind positive numbers" in {
-      val form = formProvider().bind(Map("value" -> "1"))
-      form.get shouldBe 1
-    }
+    val minimum = $minimum$
+    val maximum = $maximum$
 
-    "bind positive, comma separated numbers" in {
-      val form = formProvider().bind(Map("value" -> "10,000"))
-      form.get shouldBe 10000
-    }
+    val validDataGenerator = intsInRangeWithCommas(minimum, maximum)
 
-    "fail to bind negative numbers" in {
-      val expectedError = error("value", errorKeyMinimum, 0)
-      checkForError(formProvider(), Map("value" -> "-1"), expectedError)
-    }
+    behave like fieldThatBindsValidData(
+      form,
+      fieldName,
+      validDataGenerator
+    )
 
-    "fail to bind non-numerics" in {
-      val expectedError = error("value", errorKeyNonNumeric)
-      checkForError(formProvider(), Map("value" -> "not a number"), expectedError)
-    }
+    behave like intField(
+      form,
+      fieldName,
+      nonNumericError  = FormError(fieldName, "$className;format="decap"$.error.nonNumeric"),
+      wholeNumberError = FormError(fieldName, "$className;format="decap"$.error.wholeNumber")
+    )
 
-    "fail to bind a blank value" in {
-      val expectedError = error("value", errorKeyBlank)
-      checkForError(formProvider(), Map("value" -> ""), expectedError)
-    }
+    behave like intFieldWithRange(
+      form,
+      fieldName,
+      minimum       = minimum,
+      maximum       = maximum,
+      expectedError = FormError(fieldName, "$className;format="decap"$.error.outOfRange", Seq(minimum, maximum))
+    )
 
-    "fail to bind when value is omitted" in {
-      val expectedError = error("value", errorKeyBlank)
-      checkForError(formProvider(), emptyForm, expectedError)
-    }
-
-    "fail to bind decimal numbers" in {
-      val expectedError = error("value", errorKeyDecimal)
-      checkForError(formProvider(), Map("value" -> "123.45"), expectedError)
-    }
+    behave like mandatoryField(
+      form,
+      fieldName,
+      requiredError = FormError(fieldName, "$className;format="decap"$.error.required")
+    )
   }
 }

--- a/src/main/scaffolds/intPage/migrations/$className__snake$.sh
+++ b/src/main/scaffolds/intPage/migrations/$className__snake$.sh
@@ -19,6 +19,7 @@ echo "$className;format="decap"$.checkYourAnswersLabel = $className;format="deca
 echo "$className;format="decap"$.error.nonNumeric = Please give an answer for $className;format="decap"$ using numbers" >> ../conf/messages.en
 echo "$className;format="decap"$.error.required = Please give an answer for $className;format="decap"$" >> ../conf/messages.en
 echo "$className;format="decap"$.error.wholeNumber = Please give an answer for $className;format="decap"$ using whole numbers" >> ../conf/messages.en
+echo "$className;format="decap"$.error.outOfRange = $className;format="decap"$ must be between {0} and {1}" >> ../conf/messages.en
 
 echo "Adding helper line into UserAnswers"
 awk '/class/ {\


### PR DESCRIPTION
# Use property testing for int forms

Changed the spec for int page forms to use property-based testing
rather than specific values, as this gives us far higher levels
of confidence.

Changed the intPage scaffold itself to prompt the use for a min
and max value for the page.

## Checklist

* [x] I've included appropriate unit tests with any code I've added
* [x] I've tested by creating a new service from my fork, applying any scaffolds I've changed, and checking that all unit tests pass and the service runs as expected
* [x] I've added my code using logical, atomic commits
