### PR TITLE
Add contact-frontend port to security policy

### DIFF
--- a/src/main/g8/conf/application.conf
+++ b/src/main/g8/conf/application.conf
@@ -32,7 +32,7 @@ play.http.session.cookieName="mdtp"
 appName="$name$"
 play.http.router=prod.Routes
 
-play.filters.headers.contentSecurityPolicy= "default-src 'self' 'unsafe-inline' localhost:9000 localhost:9032 www.google-analytics.com data:"
+play.filters.headers.contentSecurityPolicy= "default-src 'self' 'unsafe-inline' localhost:9000 localhost:9032 localhost:9250 www.google-analytics.com data:"
 
 play.http.requestHandler = "uk.gov.hmrc.play.bootstrap.http.RequestHandler"
 play.http.errorHandler = "handlers.ErrorHandler"


### PR DESCRIPTION
# Add contact-frontend port to security policy

**Bug fix**
Adds localhost:9250 to the security policy so contact-frontend is no longer excluded.
Addresses issue of "Get help with this page" not working during local development.

Fixes #25 

## Checklist

* [x] I've included appropriate unit tests with any code I've added
* [x] I've tested by creating a new service from my fork, applying any scaffolds I've changed, and checking that all unit tests pass and the service runs as expected
* [x] I've added my code using logical, atomic commits
