### PR TITLE
Amended the logging levels for libraries down to INFO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## Changed
 * amended the optionsPage to include additional questions for the page title and the two radio buttons
+* Added extra loggers to logback.xml to reduce library logging down to INFO level and reduce the default chatter
 
 ## v0.5.0 - 2018-01-18
 

--- a/src/main/g8/conf/logback.xml
+++ b/src/main/g8/conf/logback.xml
@@ -49,6 +49,28 @@
 
     <logger name="application" level="DEBUG"/>
 
+    <logger name="org.asynchttpclient.netty" level="INFO"/>
+    <logger name="io.netty.buffer" level="INFO"/>
+    <logger name="play.core.netty" level="INFO"/>
+
+    <logger name="uk.gov" level="INFO"/>
+
+    <logger name="reactivemongo.core" level="INFO"/>
+    <logger name="akka" level="INFO"/>
+    <logger name="play" level="INFO"/>
+    <logger name="org.jose4j" level="INFO"/>
+    <logger name="class org.jose4j" level="INFO"/>
+
+    <logger name="javax.management" level="INFO"/>
+
+    <logger name="org.eclipse.jetty" level="INFO"/>
+
+    <logger name="org.apache.http" level="INFO"/>
+
+    <logger name="org.jboss" level="INFO"/>
+    <logger name="io.netty" level="INFO"/>
+    <logger name="sun.net.www.protocol.http" level="INFO"/>
+
     <logger name="connector" level="TRACE">
         <appender-ref ref="STDOUT"/>
     </logger>


### PR DESCRIPTION
# Amend the default logging level of a number libraries

**Bug fix**

By default, the logging level is set to DEBUG and this results in a number of libraries spewing out a lot of messages. This PR adds loggers at INFO level for some key libraries to quieten them down.

## Checklist

* [x] I've tested by creating a new service from my fork, applying any scaffolds I've changed, and checking that all unit tests pass and the service runs as expected
* [x] I've added my code using logical, atomic commits
