### PR TITLE
Enhanced the optionsPage to ask questions about the page title + radio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
+## Unreleased
+
+## Changed
+* amended the optionsPage to include additional questions for the page title and the two radio buttons
+
 ## v0.5.0 - 2018-01-18
 
 ### Added

--- a/src/main/scaffolds/optionsPage/app/models/$className$.scala
+++ b/src/main/scaffolds/optionsPage/app/models/$className$.scala
@@ -6,11 +6,11 @@ sealed trait $className$
 
 object $className$ {
 
-  case object Option1 extends WithName("option1") with $className$
-  case object Option2 extends WithName("option2") with $className$
+  case object $option1key;format="Camel"$ extends WithName("$option1key;format="decap"$") with $className$
+  case object $option2key;format="Camel"$ extends WithName("$option2key;format="decap"$") with $className$
 
   val values: Set[$className$] = Set(
-    Option1, Option2
+    $option1key;format="Camel"$, $option2key;format="Camel"$
   )
 
   val options: Set[RadioOption] = values.map {

--- a/src/main/scaffolds/optionsPage/default.properties
+++ b/src/main/scaffolds/optionsPage/default.properties
@@ -1,2 +1,7 @@
 description = Generates a controller and view for a page with a set of radio buttons
 className = MyNewPage
+title = $className;format="decap"$
+option1key = option1
+option1msg = Option 1
+option2key = option2
+option2msg = Option 2

--- a/src/main/scaffolds/optionsPage/migrations/$className__snake$.sh
+++ b/src/main/scaffolds/optionsPage/migrations/$className__snake$.sh
@@ -13,11 +13,11 @@ echo "POST       /change$className$               controllers.$className$Control
 
 echo "Adding messages to conf.messages"
 echo "" >> ../conf/messages.en
-echo "$className;format="decap"$.title = $className;format="decap"$" >> ../conf/messages.en
-echo "$className;format="decap"$.heading = $className;format="decap"$" >> ../conf/messages.en
-echo "$className;format="decap"$.option1 = $className;format="decap"$" Option 1 >> ../conf/messages.en
-echo "$className;format="decap"$.option2 = $className;format="decap"$" Option 2 >> ../conf/messages.en
-echo "$className;format="decap"$.checkYourAnswersLabel = $className;format="decap"$" >> ../conf/messages.en
+echo "$className;format="decap"$.title = $title$" >> ../conf/messages.en
+echo "$className;format="decap"$.heading = $title$" >> ../conf/messages.en
+echo "$className;format="decap"$.$option1key;format="decap"$ = $option1msg$" >> ../conf/messages.en
+echo "$className;format="decap"$.$option2key;format="decap"$ = $option2msg$" >> ../conf/messages.en
+echo "$className;format="decap"$.checkYourAnswersLabel = $title$" >> ../conf/messages.en
 echo "$className;format="decap"$.error.required = Please give an answer for $className;format="decap"$" >> ../conf/messages.en
 
 echo "Adding helper line into UserAnswers"


### PR DESCRIPTION
# Ask extra optionsPage question to produce a more complete page

**New feature**

In this PR the optionsPage has been enhanced to ask some additional questions to produce a more complete page with two working radio buttons. Extra questions are : 
* title - for the page title - (defaults to the name of the page with lower initial capital)
* option1key - the key for the 1st radio button (defaults to "option1")
* option1msg - the display text for the 1st radio button (defaults to "Option 1")
* option2key - the key for the 2nd radio button (defaults to "option2")
* option2msg - the display text for the 2nd radio button (defaults to "Option 2")

## Checklist

* [x] I've tested by creating a new service from my fork, applying any scaffolds I've changed, and checking that all unit tests pass and the service runs as expected
* [x] I've added my code using logical, atomic commits
