### PR TITLE
Add whitelist filter

### DIFF
--- a/src/main/g8/app/filters/FiltersWithWhitelist.scala
+++ b/src/main/g8/app/filters/FiltersWithWhitelist.scala
@@ -1,0 +1,11 @@
+package filters
+
+import javax.inject.Inject
+import play.api.http.DefaultHttpFilters
+import uk.gov.hmrc.play.bootstrap.filters.FrontendFilters
+
+class FiltersWithWhitelist @Inject()(
+                                      frontendFilters: FrontendFilters,
+                                      whitelistFilter: WhitelistFilter,
+                                      sessionIdFilter: SessionIdFilter
+                                    ) extends DefaultHttpFilters(frontendFilters.filters :+ whitelistFilter :+ sessionIdFilter: _*)

--- a/src/main/g8/app/filters/WhitelistFilter.scala
+++ b/src/main/g8/app/filters/WhitelistFilter.scala
@@ -1,0 +1,34 @@
+package filters
+
+import akka.stream.Materializer
+import com.google.inject.Inject
+import play.api.Configuration
+import play.api.mvc.Call
+import uk.gov.hmrc.whitelist.AkamaiWhitelistFilter
+
+class WhitelistFilter @Inject() (
+                                  config: Configuration,
+                                  override val mat: Materializer
+                                ) extends AkamaiWhitelistFilter {
+
+  override val whitelist: Seq[String] = {
+    config
+      .underlying
+      .getString("filters.whitelist.ips")
+      .split(",")
+      .map(_.trim)
+      .filter(_.nonEmpty)
+  }
+
+  override val destination: Call = {
+    val path = config.underlying.getString("filters.whitelist.destination")
+    Call("GET", path)
+  }
+
+  override val excludedPaths: Seq[Call] = {
+    config.underlying.getString("filters.whitelist.excluded").split(",").map {
+      path =>
+        Call("GET", path.trim)
+    }
+  }
+}

--- a/src/main/g8/conf/application.conf
+++ b/src/main/g8/conf/application.conf
@@ -38,6 +38,8 @@ play.http.requestHandler = "uk.gov.hmrc.play.bootstrap.http.RequestHandler"
 play.http.errorHandler = "handlers.ErrorHandler"
 play.http.filters = "filters.Filters"
 
+play.application.loader = "uk.gov.hmrc.play.bootstrap.ApplicationLoader"
+
 # Play Modules
 # ~~~~
 # Additional play modules can be added here

--- a/src/main/g8/project/FrontendBuild.scala
+++ b/src/main/g8/project/FrontendBuild.scala
@@ -29,6 +29,7 @@ private object AppDependencies {
   private val playLanguageVersion = "3.4.0"
   private val bootstrapVersion = "1.7.0"
   private val scalacheckVersion = "1.13.4"
+  private val whitelistFilterVersion = "2.0.0"
 
   val compile = Seq(
     ws,
@@ -40,7 +41,8 @@ private object AppDependencies {
     "uk.gov.hmrc" %% "http-caching-client" % httpCachingClientVersion,
     "uk.gov.hmrc" %% "play-conditional-form-mapping" % playConditionalFormMappingVersion,
     "uk.gov.hmrc" %% "bootstrap-play-25" % bootstrapVersion,
-    "uk.gov.hmrc" %% "play-language" % playLanguageVersion
+    "uk.gov.hmrc" %% "play-language" % playLanguageVersion,
+    "uk.gov.hmrc" %% "play-whitelist-filter" % whitelistFilterVersion
   )
 
   trait TestDependencies {

--- a/src/main/g8/test/filters/WhitelistFilterSpec.scala
+++ b/src/main/g8/test/filters/WhitelistFilterSpec.scala
@@ -1,0 +1,200 @@
+package filters
+
+import akka.stream.Materializer
+import com.typesafe.config.ConfigException
+import generators.Generators
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalacheck.Gen
+import org.scalatest.mockito.MockitoSugar
+import org.scalatest.prop.PropertyChecks
+import org.scalatest.{FreeSpec, MustMatchers}
+import play.api.Configuration
+import play.api.mvc.Call
+
+class WhitelistFilterSpec extends FreeSpec with MustMatchers with PropertyChecks with MockitoSugar with Generators {
+
+  val mockMaterializer = mock[Materializer]
+
+  val otherConfigGen = Gen.mapOf[String, String](
+    for {
+      key   <- Gen.alphaNumStr suchThat (_.nonEmpty)
+      value <- arbitrary[String]
+    } yield (key, value)
+  )
+
+  "the list of whitelisted IP addresses" - {
+
+    "must throw an exception" - {
+
+      "when the underlying config value is not there" in {
+
+        forAll(otherConfigGen, arbitrary[String], arbitrary[String]) {
+          (otherConfig, destination, excluded) =>
+
+            whenever(!otherConfig.contains("filters.whitelist.ips")) {
+
+              val config = Configuration(
+                (otherConfig +
+                  ("filters.whitelist.destination" -> destination) +
+                  ("filters.whitelist.excluded"    -> excluded)
+                ).toSeq: _*
+              )
+
+              assertThrows[ConfigException] {
+                new WhitelistFilter(config, mockMaterializer)
+              }
+            }
+        }
+      }
+    }
+
+    "must be empty" - {
+
+      "when the underlying config value is empty" in {
+
+        forAll(otherConfigGen, arbitrary[String], arbitrary[String]) {
+          (otherConfig, destination, excluded) =>
+
+            val config = Configuration(
+              (otherConfig +
+                ("filters.whitelist.destination" -> destination) +
+                ("filters.whitelist.excluded"    -> excluded) +
+                ("filters.whitelist.ips"         -> "")
+              ).toSeq: _*
+            )
+
+            val whitelistFilter = new WhitelistFilter(config, mockMaterializer)
+
+            whitelistFilter.whitelist mustBe empty
+          }
+      }
+    }
+
+    "must contain all of the values" - {
+
+      "when given a comma-separated list of values" in {
+
+        val gen = Gen.nonEmptyListOf(Gen.alphaNumStr suchThat (_.nonEmpty))
+
+        forAll(gen, otherConfigGen, arbitrary[String], arbitrary[String]) {
+          (ips, otherConfig, destination, excluded) =>
+
+            val ipString = ips.mkString(",")
+
+            val config = Configuration(
+              (otherConfig +
+                ("filters.whitelist.destination" -> destination) +
+                ("filters.whitelist.excluded"    -> excluded) +
+                ("filters.whitelist.ips"         -> ipString)
+              ).toSeq: _*
+            )
+
+            val whitelistFilter = new WhitelistFilter(config, mockMaterializer)
+
+            whitelistFilter.whitelist must contain theSameElementsAs ips
+        }
+      }
+    }
+  }
+
+  "the destination for non-whitelisted visitors" - {
+
+    "must throw an exception" - {
+
+      "when the underlying config value is not there" in {
+
+        forAll(otherConfigGen, arbitrary[String], arbitrary[String]) {
+          (otherConfig, destination, excluded) =>
+
+            whenever(!otherConfig.contains("filters.whitelist.destination")) {
+
+              val config = Configuration(
+                (otherConfig +
+                  ("filters.whitelist.ips"      -> destination) +
+                  ("filters.whitelist.excluded" -> excluded)
+                  ).toSeq: _*
+              )
+
+              assertThrows[ConfigException] {
+                new WhitelistFilter(config, mockMaterializer)
+              }
+            }
+        }
+      }
+    }
+
+    "must return a Call to the destination" in {
+
+      forAll(otherConfigGen, arbitrary[String], arbitrary[String], arbitrary[String]) {
+        (otherConfig, ips, destination, excluded) =>
+
+          val config = Configuration(
+            (otherConfig +
+              ("filters.whitelist.ips"         -> destination) +
+              ("filters.whitelist.excluded"    -> excluded) +
+              ("filters.whitelist.destination" -> destination)
+              ).toSeq: _*
+          )
+
+          val whitelistFilter = new WhitelistFilter(config, mockMaterializer)
+
+          whitelistFilter.destination mustEqual Call("GET", destination)
+      }
+    }
+  }
+
+  "the list of excluded paths" - {
+
+    "must throw an exception" - {
+
+      "when the underlying config value is not there" in {
+
+        forAll(otherConfigGen, arbitrary[String], arbitrary[String]) {
+          (otherConfig, destination, excluded) =>
+
+            whenever(!otherConfig.contains("filters.whitelist.excluded")) {
+
+              val config = Configuration(
+                (otherConfig +
+                  ("filters.whitelist.destination" -> destination) +
+                  ("filters.whitelist.ips"    -> excluded)
+                  ).toSeq: _*
+              )
+
+              assertThrows[ConfigException] {
+                new WhitelistFilter(config, mockMaterializer)
+              }
+            }
+        }
+      }
+    }
+
+    "must return Calls to all of the values" - {
+
+      "when given a comma-separated list of values" in {
+
+        val gen = Gen.nonEmptyListOf(Gen.alphaNumStr suchThat (_.nonEmpty))
+
+        forAll(gen, otherConfigGen, arbitrary[String], arbitrary[String]) {
+          (excludedPaths, otherConfig, destination, ips) =>
+
+            val excludedPathString = excludedPaths.mkString(",")
+
+            val config = Configuration(
+              (otherConfig +
+                ("filters.whitelist.destination" -> destination) +
+                ("filters.whitelist.excluded"    -> excludedPathString) +
+                ("filters.whitelist.ips"         -> ips)
+                ).toSeq: _*
+            )
+
+            val expectedCalls = excludedPaths.map(Call("GET", _))
+
+            val whitelistFilter = new WhitelistFilter(config, mockMaterializer)
+
+            whitelistFilter.excludedPaths must contain theSameElementsAs expectedCalls
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Add whiltelist filter

**New feature**

Added a whitelist filter using [play-whitelist-filter](https://github.com/hmrc/play-whitelist-filter).

To use the whitelist filter, enable it in `application.conf` by setting `play.http.filters` to `"filters.FiltersWithWhitelist"`.  Ensure your config also contains three keys:

* `filters.whitelist.ips.base64`: A base64-encoded, comma-separated list of IP addresses to whitelisted
* `filters.whitelist.destination`: The URL to redirect users to if their IP address isn't in the whitelist
* `filters.whitelist.excluded.base64`: A base64-encoded, comma-separated list of endpoints to exclude from checking (so all users will be able to reach the endpoint)

## Checklist

* [x] I've included appropriate unit tests with any code I've added
* [x] I've tested by creating a new service from my fork, applying any scaffolds I've changed, and checking that all unit tests pass and the service runs as expected
* [x] I've added my code using logical, atomic commits
