### PR TITLE
Turn off HMRC logo by default

### DIFF
--- a/src/main/g8/app/views/govuk_wrapper.scala.html
+++ b/src/main/g8/app/views/govuk_wrapper.scala.html
@@ -49,6 +49,7 @@
 @serviceInfo = {
     @uiLayouts.serviceInfo(
       betaBanner = HtmlFormat.empty,
+      includeHMRCBranding = false,
       includeGridWrapper = false,
       serviceInfoContent = Some(serviceInfoContent))
 }


### PR DESCRIPTION
# Turn off HMRC logo by default

Per the [design system](http://hmrc.github.io/assets-frontend/patterns/header/index.html), services should only add an HMRC header if there is a user need to know you are dealing with HMRC.

## Checklist

* [x] I've tested by creating a new service from my fork, applying any scaffolds I've changed, and checking that all unit tests pass and the service runs as expected
* [x] I've added my code using logical, atomic commits
