### PR TITLE
Fix spurious migration script error

### DIFF
--- a/src/main/g8/migrate.sh
+++ b/src/main/g8/migrate.sh
@@ -10,3 +10,6 @@ do
     mv \$file ./applied_migrations
 done
 
+echo "Moving test files from generated-test/ to test/"
+rsync -avm --include='*.scala' -f 'hide,! */' ../generated-test/ ../test/
+rm -rf ../generated-test/

--- a/src/main/scaffolds/intPage/migrations/$className__snake$.sh
+++ b/src/main/scaffolds/intPage/migrations/$className__snake$.sh
@@ -37,8 +37,4 @@ awk '/class/ {\
      print "  }";\
      next }1' ../app/utils/CheckYourAnswersHelper.scala > tmp && mv tmp ../app/utils/CheckYourAnswersHelper.scala
 
-echo "Moving test files from generated-test/ to test/"
-rsync -avm --include='*.scala' -f 'hide,! */' ../generated-test/ ../test/
-rm -rf ../generated-test/
-
 echo "Migration $className;format="snake"$ completed"

--- a/src/main/scaffolds/optionsPage/migrations/$className__snake$.sh
+++ b/src/main/scaffolds/optionsPage/migrations/$className__snake$.sh
@@ -36,8 +36,4 @@ awk '/class/ {\
      print "  }";\
      next }1' ../app/utils/CheckYourAnswersHelper.scala > tmp && mv tmp ../app/utils/CheckYourAnswersHelper.scala
 
-echo "Moving test files from generated-test/ to test/"
-rsync -avm --include='*.scala' -f 'hide,! */' ../generated-test/ ../test/
-rm -rf ../generated-test/
-
 echo "Migration $className;format="snake"$ completed"

--- a/src/main/scaffolds/page/migrations/$className__snake$.sh
+++ b/src/main/scaffolds/page/migrations/$className__snake$.sh
@@ -11,8 +11,4 @@ echo "" >> ../conf/messages.en
 echo "$className;format="decap"$.title = $className;format="decap"$" >> ../conf/messages.en
 echo "$className;format="decap"$.heading = $className;format="decap"$" >> ../conf/messages.en
 
-echo "Moving test files from generated-test/ to test/"
-rsync -avm --include='*.scala' -f 'hide,! */' ../generated-test/ ../test/
-rm -rf ../generated-test/
-
 echo "Migration $className;format="snake"$ completed"

--- a/src/main/scaffolds/questionPage/migrations/$className__snake$.sh
+++ b/src/main/scaffolds/questionPage/migrations/$className__snake$.sh
@@ -39,8 +39,4 @@ awk '/class/ {\
      print "  }";\
      next }1' ../app/utils/CheckYourAnswersHelper.scala > tmp && mv tmp ../app/utils/CheckYourAnswersHelper.scala
 
-echo "Moving test files from generated-test/ to test/"
-rsync -avm --include='*.scala' -f 'hide,! */' ../generated-test/ ../test/
-rm -rf ../generated-test/
-
 echo "Migration $className;format="snake"$ completed"

--- a/src/main/scaffolds/stringPage/migrations/$className__snake$.sh
+++ b/src/main/scaffolds/stringPage/migrations/$className__snake$.sh
@@ -35,8 +35,4 @@ awk '/class/ {\
      print "  }";\
      next }1' ../app/utils/CheckYourAnswersHelper.scala > tmp && mv tmp ../app/utils/CheckYourAnswersHelper.scala
 
-echo "Moving test files from generated-test/ to test/"
-rsync -avm --include='*.scala' -f 'hide,! */' ../generated-test/ ../test/
-rm -rf ../generated-test/
-
 echo "Migration $className;format="snake"$ completed"

--- a/src/main/scaffolds/yesNoPage/migrations/$className__snake$.sh
+++ b/src/main/scaffolds/yesNoPage/migrations/$className__snake$.sh
@@ -33,8 +33,4 @@ awk '/class/ {\
      print "    x => AnswerRow(\"$className;format="decap"$.checkYourAnswersLabel\", if(x) \"site.yes\" else \"site.no\", true, routes.$className$Controller.onPageLoad(CheckMode).url)"; print "  }";\
      next }1' ../app/utils/CheckYourAnswersHelper.scala > tmp && mv tmp ../app/utils/CheckYourAnswersHelper.scala
 
-echo "Moving test files from generated-test/ to test/"
-rsync -avm --include='*.scala' -f 'hide,! */' ../generated-test/ ../test/
-rm -rf ../generated-test/
-
 echo "Migration $className;format="snake"$ completed"


### PR DESCRIPTION
# Fix spurious migration script error

**Bug fix**

Previously, each migration script attempted to move its test files from `/generated-test` to `/test`.  However, this meant that if you applied several scaffolds then ran the migration, all of the files would be moved by the first migration script and the others would give (harmless) errors.

Shifting the responsibility for moving files to the outer script prevents these errors occurring.

## Checklist

* [x] I've tested by creating a new service from my fork, applying any scaffolds I've changed, and checking that all unit tests pass and the service runs as expected
* [x] I've added my code using logical, atomic commits
