### PR TITLE
Remove char counter from textarea

### DIFF
--- a/src/main/g8/app/views/components/input_textarea.scala.html
+++ b/src/main/g8/app/views/components/input_textarea.scala.html
@@ -3,13 +3,13 @@
         label: String,
         secondaryLabel: Option[String] = None,
         inputClass: Option[String] = None,
-        hint: Option[String] = None,
-        charLimit: Option[Int] = None
+        labelClass: Option[String] = None,
+        hint: Option[String] = None
 )(implicit messages: Messages)
 
 <div class="form-group @if(field.hasErrors){form-group-error}">
     <label class="form-label" for="@{field.id}">
-        <span class="bold">@label</span>
+        <span class="bold @labelClass">@label</span>
         @hint.map { hint =>
             <span class="form-hint">@hint</span>
         }
@@ -24,16 +24,8 @@
         name="@{field.id}"
         value="@{field.value}"
         aria-describedby="error-message-@{field.id}-input"
-            @if(charLimit.isDefined){maxLength="@{charLimit}"}
-        data-char-field
-        cols="30"
-        rows="20"
+        rows="5"
         ></textarea>
-        @if(charLimit.isDefined){
-            <noscript>
-                <p class="char-counter-text flush">@messages("site.textarea.char_limit", charLimit.get)</p>
-            </noscript>
-        }
     </div>
 </div>
 

--- a/src/main/g8/test/generators/Generators.scala
+++ b/src/main/g8/test/generators/Generators.scala
@@ -74,8 +74,11 @@ trait Generators extends CacheMapGenerator with PageGenerators with ModelGenerat
       chars <- listOfN(length, arbitrary[Char])
     } yield chars.mkString
 
-  def stringsLongerThan(minLength: Int): Gen[String] =
-    arbitrary[String] suchThat (_.length > minLength)
+  def stringsLongerThan(minLength: Int): Gen[String] = for {
+    maxLength <- (minLength * 2).max(100)
+    length    <- Gen.chooseNum(minLength + 1, maxLength)
+    chars     <- listOfN(length, arbitrary[Char])
+  } yield chars.mkString
 
   def stringsExceptSpecificValues(excluded: Set[String]): Gen[String] =
     nonEmptyString suchThat (!excluded.contains(_))


### PR DESCRIPTION
# Remove char counter from textarea

The current standard pattern for textareas does not include a JS character counter, so I've removed it and allowed the label to be provided with a class.

I've also improved a generator to prevent scalacheck from discarding too many values when inputs can be very large.

## Checklist

* [x] I've tested by creating a new service from my fork, applying any scaffolds I've changed, and checking that all unit tests pass and the service runs as expected
* [x] I've added my code using logical, atomic commits
