### PR TITLE
fixed issue with displaying and testing textareas

### DIFF
--- a/src/main/g8/app/views/components/input_textarea.scala.html
+++ b/src/main/g8/app/views/components/input_textarea.scala.html
@@ -19,13 +19,14 @@
     </label>
     <div class="form-control-wrapper char-counter" data-char-counter>
         <textarea
-        class="form-control form-control--full-width @inputClass"
-        id="@{field.id}"
-        name="@{field.id}"
-        value="@{field.value}"
-        aria-describedby="error-message-@{field.id}-input"
-        rows="5"
-        ></textarea>
+            class="form-control form-control--full-width @inputClass"
+            id="@{field.id}"
+            name="@{field.id}"
+            @if(field.hasErrors) { aria-describedby="error-message-@{field.id}-input" }
+            rows="5">
+
+            @{field.value}
+        </textarea>
     </div>
 </div>
 

--- a/src/main/g8/test/views/ViewSpecBase.scala
+++ b/src/main/g8/test/views/ViewSpecBase.scala
@@ -53,7 +53,7 @@ trait ViewSpecBase extends SpecBase {
     val labels = doc.getElementsByAttributeValue("for", forElement)
     assert(labels.size == 1, s"\n\nLabel for \$forElement was not rendered on the page.")
     val label = labels.first
-    assert(label.text() == expectedText, s"\n\nLabel for \$forElement was not \$expectedText")
+    assert(label.text().contains(expectedText), s"\n\nLabel for \$forElement was not \$expectedText")
 
     if (expectedHintText.isDefined) {
       assert(label.getElementsByClass("form-hint").first.text == expectedHintText.get,


### PR DESCRIPTION
# Fixed some issues around textareas

**Bug fix**

Text areas do not display form content as the value attribute is used and should be the body instead.
The aria-describedby attribute is always displayed but should only be displayed when there is an error.
The assertContainsLabel test does a `==` instead of a `.contains` this means the test always fails if hint text is supplied

## Checklist

* [x] I've included appropriate unit tests with any code I've added
* [x] I've tested by creating a new service from my fork, applying any scaffolds I've changed, and checking that all unit tests pass and the service runs as expected
* [x] I've added my code using logical, atomic commits
