### PR TITLE
Remove unsafe-inline and data: from CSP

### DIFF
--- a/src/main/g8/conf/application.conf
+++ b/src/main/g8/conf/application.conf
@@ -32,7 +32,7 @@ play.http.session.cookieName="mdtp"
 appName="$name$"
 play.http.router=prod.Routes
 
-play.filters.headers.contentSecurityPolicy= "default-src 'self' 'unsafe-inline' localhost:9000 localhost:9032 localhost:9250 www.google-analytics.com data:"
+play.filters.headers.contentSecurityPolicy= "default-src 'self' localhost:9000 localhost:9032 localhost:9250 www.google-analytics.com"
 
 play.http.requestHandler = "uk.gov.hmrc.play.bootstrap.http.RequestHandler"
 play.http.errorHandler = "handlers.ErrorHandler"


### PR DESCRIPTION
We should not have these in the CSP as per guidance. These should be added only if needed, not presented by default only to be left in.