### PR TITLE
[accessibleErrorSummaryMarkup] Change role='group' to role='alert' following a DAC report

### DIFF
--- a/src/main/g8/app/views/components/error_summary.scala.html
+++ b/src/main/g8/app/views/components/error_summary.scala.html
@@ -1,6 +1,6 @@
 @(errors: Seq[FormError])(implicit messages: Messages)
 @if(errors.nonEmpty) {
-    <div class="error-summary error-summary--show" role="group" aria-labelledby="error-summary-heading" tabindex="-1">
+    <div class="error-summary error-summary--show" role="alert" aria-labelledby="error-summary-heading" tabindex="-1">
 
         <h2 class="heading-medium error-summary-heading" id="error-summary-heading">
         @messages("error.summary.title")


### PR DESCRIPTION
# Correct Error Summary Component Markup, based on accessibility comments received from DAC.

**Bug fix**

Error Summary Component incorrectly has `role='group'` according to the DAC report (and the GDS Design System) the role should be 'alert'.

## Checklist

* [ ] I've included appropriate unit tests with any code I've added
* [x] I've tested by creating a new service from my fork, applying any scaffolds I've changed, and checking that all unit tests pass and the service runs as expected
* [x] I've added my code using logical, atomic commits
