### PR TITLE
Adds correct footer link content

### DIFF
--- a/src/main/g8/conf/messages.en
+++ b/src/main/g8/conf/messages.en
@@ -42,3 +42,9 @@ site.textarea.char_limit = (Limit is {0} characters)
 
 unauthorised.title = You can’t access this service with this account
 unauthorised.heading = You can’t access this service with this account
+
+footer.accessibility = Accessibility Statement
+footer.cookies = Cookies
+footer.privacy = Privacy policy
+footer.terms = Terms and conditions
+footer.help = Help using GOV.UK


### PR DESCRIPTION
An attempt to stop the need for people to copy/paste incorrectly from other services, which has been leading to the Accessibility Statement link being mislabeled as just Accessibility. 