### PR TITLE
FakeDataRetrievalAction Pass data Option straight through

### DIFF
--- a/src/main/g8/test/controllers/actions/FakeDataRetrievalAction.scala
+++ b/src/main/g8/test/controllers/actions/FakeDataRetrievalAction.scala
@@ -8,12 +8,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class FakeDataRetrievalAction(dataToReturn: Option[UserAnswers]) extends DataRetrievalAction {
 
   override protected def transform[A](request: IdentifierRequest[A]): Future[OptionalDataRequest[A]] =
-    dataToReturn match {
-      case None =>
-        Future(OptionalDataRequest(request.request, request.identifier, None))
-      case Some(userAnswers) =>
-        Future(OptionalDataRequest(request.request, request.identifier, Some(userAnswers)))
-    }
+    Future(OptionalDataRequest(request.request, request.identifier, dataToReturn))
 
   override protected implicit val executionContext: ExecutionContext =
     scala.concurrent.ExecutionContext.Implicits.global


### PR DESCRIPTION
# Descriptive Title
The original code unwrapped an option to wrap it back up again. This is unnecessary.
**Tech Debt** 

