### PR TITLE
Update app js to prevent null pointer error when there is no back link

### DIFF
--- a/src/main/g8/app/assets/javascripts/app.js
+++ b/src/main/g8/app/assets/javascripts/app.js
@@ -3,9 +3,15 @@ if (window.history && window.history.replaceState && typeof window.history.repla
   window.history.replaceState(null, null, window.location.href);
 }
 
-// handle back click
-document.querySelector('.govuk-back-link').addEventListener('click', function(e){
-  e.preventDefault();
-  e.stopPropagation();
-  window.history.back();
+document.addEventListener('DOMContentLoaded', function(event) {
+
+  // handle back click
+  var backLink = document.querySelector('.govuk-back-link');
+  if (backLink !== null) {
+    backLink.addEventListener('click', function(e){
+      e.preventDefault();
+      e.stopPropagation();
+      window.history.back();
+    });
+  }
 });


### PR DESCRIPTION
# Fix null pointer error in app.js

**Bug fix** 

The app.js file adds event handlers to back links on a page but assumes that one exists, if there is a page without a back link this leads to a null pointer error which breaks js for that page. This is especially bad as it will break things like GTM on those pages.

## Checklist

I haven't gone through this checklist but it's a single file which is in the base project rather than any of the scaffolds, I've also taken this fix from a scaffolded service to check that it works.

* [ ] I've included appropriate unit tests with any code I've added
* [ ] I've tested by creating a new service from my fork, applying any scaffolds I've changed, and checking that all unit tests pass and the service runs as expected
* [ ] I've added my code using logical, atomic commits
