### PR TITLE
Java 11 updates

### DIFF
--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -68,10 +68,7 @@ lazy val root = (project in file("."))
   )
 
 lazy val testSettings: Seq[Def.Setting[_]] = Seq(
-  fork        := true,
-  javaOptions ++= Seq(
-    "-Dconfig.resource=test.application.conf"
-  ),
+  fork := true,
   unmanagedSourceDirectories += baseDirectory.value / "test-utils"
 )
 
@@ -84,8 +81,5 @@ lazy val itSettings = Defaults.itSettings ++ Seq(
     baseDirectory.value / "it" / "resources"
   ),
   parallelExecution := false,
-  fork := true,
-  javaOptions ++= Seq(
-    "-Dconfig.resource=it.application.conf"
-  )
+  fork := true
 )

--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -1,7 +1,6 @@
 import play.sbt.routes.RoutesKeys
 import sbt.Def
 import scoverage.ScoverageKeys
-import uk.gov.hmrc.DefaultBuildSettings
 import uk.gov.hmrc.versioning.SbtGitVersioning.autoImport.majorVersion
 
 lazy val appName: String = "$name$"
@@ -9,8 +8,6 @@ lazy val appName: String = "$name$"
 lazy val root = (project in file("."))
   .enablePlugins(PlayScala, SbtAutoBuildPlugin, SbtDistributablesPlugin)
   .disablePlugins(JUnitXmlReportPlugin) //Required to prevent https://github.com/scalatest/scalatest/issues/1427
-  .settings(DefaultBuildSettings.scalaSettings: _*)
-  .settings(DefaultBuildSettings.defaultSettings(): _*)
   .settings(SbtDistributablesPlugin.publishingSettings: _*)
   .settings(inConfig(Test)(testSettings): _*)
   .configs(IntegrationTest)

--- a/src/main/g8/it/repositories/SessionRepositorySpec.scala
+++ b/src/main/g8/it/repositories/SessionRepositorySpec.scala
@@ -13,6 +13,7 @@ import play.api.libs.json.Json
 import uk.gov.hmrc.mongo.test.DefaultPlayMongoRepositorySupport
 
 import java.time.{Clock, Instant, ZoneId}
+import java.time.temporal.ChronoUnit
 import scala.concurrent.ExecutionContext.Implicits.global
 
 class SessionRepositorySpec
@@ -24,7 +25,7 @@ class SessionRepositorySpec
     with OptionValues
     with MockitoSugar {
 
-  private val instant = Instant.now
+  private val instant = Instant.now.truncatedTo(ChronoUnit.MILLIS)
   private val stubClock: Clock = Clock.fixed(instant, ZoneId.systemDefault)
 
   private val userAnswers = UserAnswers("id", Json.obj("foo" -> "bar"), Instant.ofEpochSecond(1))

--- a/src/main/g8/it/resources/application.conf
+++ b/src/main/g8/it/resources/application.conf
@@ -1,5 +1,3 @@
-include "application.conf"
-
 mongodb.uri = "mongodb://localhost:27017/$name$-integration"
 
 akka {

--- a/src/main/g8/project/plugins.sbt
+++ b/src/main/g8/project/plugins.sbt
@@ -4,7 +4,7 @@ resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts
 
 resolvers += "Typesafe Releases" at "https://repo.typesafe.com/typesafe/releases/"
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.6.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.7.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "2.4.0")
 

--- a/src/main/g8/test/resources/application.conf
+++ b/src/main/g8/test/resources/application.conf
@@ -1,5 +1,3 @@
-include "application.conf"
-
 bootstrap.filters.csrf.enabled = false
 
 play.http.secret.key = "some_secret"


### PR DESCRIPTION
# Updates to allow building with Java 11

**New feature**

This updates sbt-auto-build to a version which will allow the service to be built in Intellij with Java 11. It also makes changes to the SessionRepositorySpec to make it work with Java 11.

It also removes some redundant build settings in build.sbt which are already set automatically by their associated plugins.

This also changes how the test versions of the application.conf are used to make it easier to run tests in Intellij.

## Checklist

* [X] I've included appropriate unit tests with any code I've added
* [X] I've tested by creating a new service from my fork, applying any scaffolds I've changed, and checking that all unit tests pass and the service runs as expected
* [X] I've added my code using logical, atomic commits
