### PR TITLE
Fix `.asNumeric` method on `InputFluency`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
+## v0.27.0 - 2022-08-17
+
+### Fixed
+* `.asNumeric()` on `InputFluency` now correctly sets the inputmode
 ## v0.26.0 - 2022-08-10
 
 ### Changed

--- a/src/main/g8/app/viewmodels/govuk/InputFluency.scala
+++ b/src/main/g8/app/viewmodels/govuk/InputFluency.scala
@@ -36,7 +36,7 @@ trait InputFluency {
 
     def asNumeric(): Input =
       input
-        .withInputType("numeric")
+        .withInputMode("numeric")
         .withPattern("[0-9]*")
 
     def withId(id: String): Input =

--- a/src/main/g8/project/build.properties
+++ b/src/main/g8/project/build.properties
@@ -1,2 +1,2 @@
 sbt.version=1.5.8
-hmrc-frontend-scaffold.version=0.26.0
+hmrc-frontend-scaffold.version=0.27.0


### PR DESCRIPTION
# Fix `.asNumeric` method on `InputFluency`

Bug fix - `asNumeric` now sets `inputmode` to `numeric`, rather than `inputtype`.
