### PR TITLE
Add .sbtopts file

### DIFF
--- a/src/main/g8/.sbtopts
+++ b/src/main/g8/.sbtopts
@@ -1,0 +1,1 @@
+-Dsbt.supershell=false


### PR DESCRIPTION
# Fix issue with supershell breaking the g8Scaffold task

**Bug fix**

Add .sbtopts file to disable powershell to fix issue with supershell breaking the g8Scaffold task

## Checklist

* [ x ] I've included appropriate unit tests with any code I've added
* [ x ] I've tested by creating a new service from my fork, applying any scaffolds I've changed, and checking that all unit tests pass and the service runs as expected
* [ x ] I've added my code using logical, atomic commits
