### PR TITLE
Date page improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
+## v0.31.0 - 2023-11-21
+
+### Changed
+* Updated LocalDate formatter to allow months to be supplied as names (e.g. January) or abbreviations (e.g. Jan)
+* Updated dependencies
+
+### Fixed
+* Make sure errors messages when parts of a date are omitted are internationalised
+
 ## v0.30.0 - 2023-07-05
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 * Make sure errors messages when parts of a date are omitted are internationalised
+* Only highlight specific day/month/fields in red when we know the problem is with specific field(s)
 
 ## v0.30.0 - 2023-07-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Fixed
 * Make sure errors messages when parts of a date are omitted are internationalised
 * Only highlight specific day/month/fields in red when we know the problem is with specific field(s)
+* Pass langauge code to the timeout dialog so its message is internationalised properly
 
 ## v0.30.0 - 2023-07-05
 

--- a/src/main/g8/app/forms/mappings/LocalDateFormatter.scala
+++ b/src/main/g8/app/forms/mappings/LocalDateFormatter.scala
@@ -2,6 +2,7 @@ package forms.mappings
 
 import play.api.data.FormError
 import play.api.data.format.Formatter
+import play.api.i18n.Messages
 
 import java.time.{LocalDate, Month}
 import scala.util.{Failure, Success, Try}
@@ -12,7 +13,7 @@ private[mappings] class LocalDateFormatter(
                                             twoRequiredKey: String,
                                             requiredKey: String,
                                             args: Seq[String] = Seq.empty
-                                          ) extends Formatter[LocalDate] with Formatters {
+                                          )(implicit messages: Messages) extends Formatter[LocalDate] with Formatters {
 
   private val fieldKeys: List[String] = List("day", "month", "year")
 
@@ -54,6 +55,7 @@ private[mappings] class LocalDateFormatter(
       .withFilter(_._2.isEmpty)
       .map(_._1)
       .toList
+      .map(field => messages(s"date.error.\$field"))
 
     fields.count(_._2.isDefined) match {
       case 3 =>

--- a/src/main/g8/app/forms/mappings/Mappings.scala
+++ b/src/main/g8/app/forms/mappings/Mappings.scala
@@ -1,10 +1,11 @@
 package forms.mappings
 
-import java.time.LocalDate
-
+import models.Enumerable
 import play.api.data.FieldMapping
 import play.api.data.Forms.of
-import models.Enumerable
+import play.api.i18n.Messages
+
+import java.time.LocalDate
 
 trait Mappings extends Formatters with Constraints {
 
@@ -33,6 +34,6 @@ trait Mappings extends Formatters with Constraints {
                            allRequiredKey: String,
                            twoRequiredKey: String,
                            requiredKey: String,
-                           args: Seq[String] = Seq.empty): FieldMapping[LocalDate] =
+                           args: Seq[String] = Seq.empty)(implicit messages: Messages): FieldMapping[LocalDate] =
     of(new LocalDateFormatter(invalidKey, allRequiredKey, twoRequiredKey, requiredKey, args))
 }

--- a/src/main/g8/app/viewmodels/govuk/DateFluency.scala
+++ b/src/main/g8/app/viewmodels/govuk/DateFluency.scala
@@ -27,7 +27,17 @@ trait DateFluency {
                fieldset: Fieldset
              )(implicit messages: Messages): DateInput = {
 
-      val errorClass = if (errorMessage(field).isDefined) "govuk-input--error" else ""
+      val errorClass = "govuk-input--error"
+
+      val dayError         = field.error.exists(_.args.contains(messages("date.error.day")))
+      val monthError       = field.error.exists(_.args.contains(messages("date.error.month")))
+      val yearError        = field.error.exists(_.args.contains(messages("date.error.year")))
+      val anySpecificError = dayError || monthError || yearError
+      val allFieldsError   = field.error.isDefined && !anySpecificError
+
+      val dayErrorClass   = if (dayError || allFieldsError) errorClass else ""
+      val monthErrorClass = if (monthError || allFieldsError) errorClass else ""
+      val yearErrorClass  = if (yearError || allFieldsError) errorClass else ""
 
       val items = Seq(
         InputItem(
@@ -35,21 +45,21 @@ trait DateFluency {
           name    = s"\${field.name}.day",
           value   = field("day").value,
           label   = Some(messages("date.day")),
-          classes = s"govuk-input--width-2 \$errorClass".trim
+          classes = s"govuk-input--width-2 \$dayErrorClass".trim
         ),
         InputItem(
           id      = s"\${field.id}.month",
           name    = s"\${field.name}.month",
           value   = field("month").value,
           label   = Some(messages("date.month")),
-          classes = s"govuk-input--width-2 \$errorClass".trim
+          classes = s"govuk-input--width-2 \$monthErrorClass".trim
         ),
         InputItem(
           id      = s"\${field.id}.year",
           name    = s"\${field.name}.year",
           value   = field("year").value,
           label   = Some(messages("date.year")),
-          classes = s"govuk-input--width-4 \$errorClass".trim
+          classes = s"govuk-input--width-4 \$yearErrorClass".trim
         )
       )
 

--- a/src/main/g8/app/views/templates/Layout.scala.html
+++ b/src/main/g8/app/views/templates/Layout.scala.html
@@ -31,7 +31,8 @@
                 signOutUrl          = Some(controllers.auth.routes.AuthController.signOut.url),
                 signOutButtonText   = Some(messages("timeout.signOut")),
                 title               = Some(messages("timeout.title")),
-                message             = Some(messages("timeout.message"))
+                message             = Some(messages("timeout.message")),
+                language            = Some(messages.lang.code)
             )))
         } else None
     )

--- a/src/main/g8/conf/messages.en
+++ b/src/main/g8/conf/messages.en
@@ -14,6 +14,9 @@ site.govuk = GOV.UK
 date.day = Day
 date.month = Month
 date.year = Year
+date.error.day = day
+date.error.month = month
+date.error.year = year
 
 timeout.title = You’re about to be signed out
 timeout.message = For security reasons, you will be signed out of this service in

--- a/src/main/g8/project/AppDependencies.scala
+++ b/src/main/g8/project/AppDependencies.scala
@@ -2,12 +2,12 @@ import sbt._
 
 object AppDependencies {
 
-  private val bootstrapVersion = "7.22.0"
-  private val hmrcMongoVersion = "1.2.0"
+  private val bootstrapVersion = "7.23.0"
+  private val hmrcMongoVersion = "1.4.0"
 
   val compile = Seq(
     play.sbt.PlayImport.ws,
-    "uk.gov.hmrc"       %% "play-frontend-hmrc"             % "7.9.0-play-28",
+    "uk.gov.hmrc"       %% "play-frontend-hmrc"             % "7.28.0-play-28",
     "uk.gov.hmrc"       %% "play-conditional-form-mapping"  % "1.13.0-play-28",
     "uk.gov.hmrc"       %% "bootstrap-frontend-play-28"     % bootstrapVersion,
     "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-28"             % hmrcMongoVersion

--- a/src/main/g8/project/build.properties
+++ b/src/main/g8/project/build.properties
@@ -1,2 +1,2 @@
 sbt.version=1.7.2
-hmrc-frontend-scaffold.version=0.30.0
+hmrc-frontend-scaffold.version=0.31.0

--- a/src/main/g8/project/plugins.sbt
+++ b/src/main/g8/project/plugins.sbt
@@ -4,7 +4,7 @@ resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts
 
 resolvers += "Typesafe Releases" at "https://repo.typesafe.com/typesafe/releases/"
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.9.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.15.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.2.0")
 

--- a/src/main/g8/test/forms/mappings/DateMappingsSpec.scala
+++ b/src/main/g8/test/forms/mappings/DateMappingsSpec.scala
@@ -9,9 +9,13 @@ import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import play.api.data.{Form, FormError}
+import play.api.i18n.Messages
+import play.api.test.Helpers.stubMessages
 
 class DateMappingsSpec extends AnyFreeSpec with Matchers with ScalaCheckPropertyChecks with Generators with OptionValues
   with Mappings {
+
+  private implicit val messages: Messages = stubMessages()
 
   val form = Form(
     "value" -> localDate(
@@ -140,7 +144,7 @@ class DateMappingsSpec extends AnyFreeSpec with Matchers with ScalaCheckProperty
 
         val result = form.bind(data)
 
-        result.errors must contain only FormError("value", "error.required", List("day"))
+        result.errors must contain only FormError("value", "error.required", List(messages("date.error.day")))
     }
   }
 
@@ -180,7 +184,7 @@ class DateMappingsSpec extends AnyFreeSpec with Matchers with ScalaCheckProperty
 
         val result = form.bind(data)
 
-        result.errors must contain only FormError("value", "error.required", List("month"))
+        result.errors must contain only FormError("value", "error.required", List(messages("date.error.month")))
     }
   }
 
@@ -220,7 +224,7 @@ class DateMappingsSpec extends AnyFreeSpec with Matchers with ScalaCheckProperty
 
         val result = form.bind(data)
 
-        result.errors must contain only FormError("value", "error.required", List("year"))
+        result.errors must contain only FormError("value", "error.required", List(messages("date.error.year")))
     }
   }
 
@@ -264,7 +268,7 @@ class DateMappingsSpec extends AnyFreeSpec with Matchers with ScalaCheckProperty
 
         val result = form.bind(data)
 
-        result.errors must contain only FormError("value", "error.required.two", List("day", "month"))
+        result.errors must contain only FormError("value", "error.required.two", List(messages("date.error.day"), messages("date.error.month")))
     }
   }
 
@@ -289,7 +293,7 @@ class DateMappingsSpec extends AnyFreeSpec with Matchers with ScalaCheckProperty
 
         val result = form.bind(data)
 
-        result.errors must contain only FormError("value", "error.required.two", List("day", "year"))
+        result.errors must contain only FormError("value", "error.required.two", List(messages("date.error.day"), messages("date.error.year")))
     }
   }
 
@@ -314,7 +318,7 @@ class DateMappingsSpec extends AnyFreeSpec with Matchers with ScalaCheckProperty
 
         val result = form.bind(data)
 
-        result.errors must contain only FormError("value", "error.required.two", List("month", "year"))
+        result.errors must contain only FormError("value", "error.required.two", List(messages("date.error.month"), messages("date.error.year")))
     }
   }
 

--- a/src/main/g8/test/forms/mappings/DateMappingsSpec.scala
+++ b/src/main/g8/test/forms/mappings/DateMappingsSpec.scala
@@ -31,7 +31,7 @@ class DateMappingsSpec extends AnyFreeSpec with Matchers with ScalaCheckProperty
 
   val missingField: Gen[Option[String]] = Gen.option(Gen.const(""))
 
-  "must bind valid data" in {
+  "must bind valid dates with months provided as numbers" in {
 
     forAll(validData -> "valid date") {
       date =>
@@ -39,6 +39,74 @@ class DateMappingsSpec extends AnyFreeSpec with Matchers with ScalaCheckProperty
         val data = Map(
           "value.day" -> date.getDayOfMonth.toString,
           "value.month" -> date.getMonthValue.toString,
+          "value.year" -> date.getYear.toString
+        )
+
+        val result = form.bind(data)
+
+        result.value.value mustEqual date
+    }
+  }
+
+  "must bind valid dates with months provided as full names in upper case" in {
+
+    forAll(validData -> "valid date") {
+      date =>
+
+        val data = Map(
+          "value.day" -> date.getDayOfMonth.toString,
+          "value.month" -> date.getMonth.toString,
+          "value.year" -> date.getYear.toString
+        )
+
+        val result = form.bind(data)
+
+        result.value.value mustEqual date
+    }
+  }
+
+  "must bind valid dates with months provided as full names in lower case" in {
+
+    forAll(validData -> "valid date") {
+      date =>
+
+        val data = Map(
+          "value.day" -> date.getDayOfMonth.toString,
+          "value.month" -> date.getMonth.toString.toLowerCase,
+          "value.year" -> date.getYear.toString
+        )
+
+        val result = form.bind(data)
+
+        result.value.value mustEqual date
+    }
+  }
+
+  "must bind valid dates with months provided as three characters in upper case" in {
+
+    forAll(validData -> "valid date") {
+      date =>
+
+        val data = Map(
+          "value.day" -> date.getDayOfMonth.toString,
+          "value.month" -> date.getMonth.toString.take(3),
+          "value.year" -> date.getYear.toString
+        )
+
+        val result = form.bind(data)
+
+        result.value.value mustEqual date
+    }
+  }
+
+  "must bind valid dates with months provided as three characters in lower case" in {
+
+    forAll(validData -> "valid date") {
+      date =>
+
+        val data = Map(
+          "value.day" -> date.getDayOfMonth.toString,
+          "value.month" -> date.getMonth.toString.take(3).toLowerCase,
           "value.year" -> date.getYear.toString
         )
 

--- a/src/main/g8/test/viewmodels/govuk/DateFluencySpec.scala
+++ b/src/main/g8/test/viewmodels/govuk/DateFluencySpec.scala
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package viewmodels.govuk
+
+import forms.mappings.Mappings
+import org.scalatest.OptionValues
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.must.Matchers
+import play.api.data.Form
+import play.api.i18n.Messages
+import play.api.test.Helpers.stubMessages
+import viewmodels.govuk.all._
+
+import java.time.LocalDate
+
+class DateFluencySpec extends AnyFreeSpec with Matchers with Mappings with OptionValues {
+
+  ".apply"- {
+
+    implicit val messages: Messages = stubMessages()
+
+    val fieldset = FieldsetViewModel(LegendViewModel("foo"))
+
+    val form : Form[LocalDate] =
+      Form(
+        "value" -> localDate(
+          invalidKey = "fieldName.error.invalid",
+          allRequiredKey = "fieldName.error.required.all",
+          twoRequiredKey = "fieldName.error.required.two",
+          requiredKey = "fieldName.error.required"
+        )
+      )
+
+    val errorClass = "govuk-input--error"
+
+    "must highlight all fields when there is an error, but the error does not specify any individual day/month/year field" in {
+
+      val boundForm = form.bind(Map.empty[String, String])
+
+      val result = DateViewModel(boundForm("value"), fieldset)
+
+      result.items.forall(_.classes.contains(errorClass)) mustEqual true
+    }
+
+    "must highlight the day field when the error is that a day is missing" in {
+
+      val boundForm = form.bind(Map(
+        "value.month" -> "1",
+        "value.year" -> "2000"
+      ))
+
+      val result = DateViewModel(boundForm("value"), fieldset)
+
+      result.items.find(_.id == "value.day").value.classes must include(errorClass)
+      result.items.find(_.id == "value.month").value.classes must not include errorClass
+      result.items.find(_.id == "value.year").value.classes must not include errorClass
+    }
+
+    "must highlight the day and month fields when the error is that a day and month are both missing" in {
+
+      val boundForm = form.bind(Map(
+        "value.year" -> "2000"
+      ))
+
+      val result = DateViewModel(boundForm("value"), fieldset)
+
+      result.items.find(_.id == "value.day").value.classes must include(errorClass)
+      result.items.find(_.id == "value.month").value.classes must include(errorClass)
+      result.items.find(_.id == "value.year").value.classes must not include (errorClass)
+    }
+
+    "must highlight the day and year fields when the error is that a day and year are both missing" in {
+
+      val boundForm = form.bind(Map(
+        "value.month" -> "1"
+      ))
+
+      val result = DateViewModel(boundForm("value"), fieldset)
+
+      result.items.find(_.id == "value.day").value.classes must include(errorClass)
+      result.items.find(_.id == "value.month").value.classes must not include errorClass
+      result.items.find(_.id == "value.year").value.classes must include(errorClass)
+    }
+
+    "must highlight the month field when the error is that a month is missing" in {
+
+      val boundForm = form.bind(Map(
+        "value.day" -> "1",
+        "value.year" -> "2000"
+      ))
+
+      val result = DateViewModel(boundForm("value"), fieldset)
+
+      result.items.find(_.id == "value.day").value.classes must not include errorClass
+      result.items.find(_.id == "value.month").value.classes must include(errorClass)
+      result.items.find(_.id == "value.year").value.classes must not include errorClass
+    }
+
+    "must highlight the month and year fields when the error is that a month and year are both missing" in {
+
+      val boundForm = form.bind(Map(
+        "value.day" -> "1"
+      ))
+
+      val result = DateViewModel(boundForm("value"), fieldset)
+
+      result.items.find(_.id == "value.day").value.classes must not include errorClass
+      result.items.find(_.id == "value.month").value.classes must include(errorClass)
+      result.items.find(_.id == "value.year").value.classes must include(errorClass)
+    }
+
+    "must highlight the year field when the error is that a year is missing" in {
+
+      val boundForm = form.bind(Map(
+        "value.day" -> "1",
+        "value.month" -> "1"
+      ))
+
+      val result = DateViewModel(boundForm("value"), fieldset)
+
+      result.items.find(_.id == "value.day").value.classes must not include errorClass
+      result.items.find(_.id == "value.month").value.classes must not include errorClass
+      result.items.find(_.id == "value.year").value.classes must include(errorClass)
+    }
+
+    "must not highlight any fields when there is not an error" in {
+
+      val boundForm = form.bind(Map(
+        "value.day" -> "1",
+        "value.month" -> "1",
+        "value.year" -> "2000"
+      ))
+
+      val result = DateViewModel(boundForm("value"), fieldset)
+
+      result.items.forall(_.classes.contains(errorClass)) mustEqual false
+    }
+  }
+}

--- a/src/main/scaffolds/datePage/app/controllers/$className$Controller.scala
+++ b/src/main/scaffolds/datePage/app/controllers/$className$Controller.scala
@@ -26,11 +26,11 @@ class $className$Controller @Inject()(
                                         view: $className$View
                                       )(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport {
 
-  def form = formProvider()
-
   def onPageLoad(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData) {
     implicit request =>
 
+      val form = formProvider()
+      
       val preparedForm = request.userAnswers.get($className$Page) match {
         case None => form
         case Some(value) => form.fill(value)
@@ -42,6 +42,8 @@ class $className$Controller @Inject()(
   def onSubmit(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData).async {
     implicit request =>
 
+      val form = formProvider()
+      
       form.bindFromRequest().fold(
         formWithErrors =>
           Future.successful(BadRequest(view(formWithErrors, mode))),

--- a/src/main/scaffolds/datePage/app/forms/$className$FormProvider.scala
+++ b/src/main/scaffolds/datePage/app/forms/$className$FormProvider.scala
@@ -1,14 +1,15 @@
 package forms
 
-import java.time.LocalDate
-
 import forms.mappings.Mappings
-import javax.inject.Inject
 import play.api.data.Form
+import play.api.i18n.Messages
+
+import java.time.LocalDate
+import javax.inject.Inject
 
 class $className$FormProvider @Inject() extends Mappings {
 
-  def apply(): Form[LocalDate] =
+  def apply()(implicit messages: Messages): Form[LocalDate] =
     Form(
       "value" -> localDate(
         invalidKey     = "$className;format="decap"$.error.invalid",

--- a/src/main/scaffolds/datePage/generated-test/controllers/$className$ControllerSpec.scala
+++ b/src/main/scaffolds/datePage/generated-test/controllers/$className$ControllerSpec.scala
@@ -10,6 +10,7 @@ import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.scalatestplus.mockito.MockitoSugar
 import pages.$className$Page
+import play.api.i18n.Messages
 import play.api.inject.bind
 import play.api.mvc.{AnyContentAsEmpty, AnyContentAsFormUrlEncoded, Call}
 import play.api.test.FakeRequest
@@ -21,7 +22,9 @@ import scala.concurrent.Future
 
 class $className$ControllerSpec extends SpecBase with MockitoSugar {
 
-  val formProvider = new $className$FormProvider()
+  private implicit val messages: Messages = stubMessages()
+
+  private val formProvider = new $className$FormProvider()
   private def form = formProvider()
 
   def onwardRoute = Call("GET", "/foo")

--- a/src/main/scaffolds/datePage/generated-test/forms/$className$FormProviderSpec.scala
+++ b/src/main/scaffolds/datePage/generated-test/forms/$className$FormProviderSpec.scala
@@ -1,12 +1,14 @@
 package forms
 
 import java.time.{LocalDate, ZoneOffset}
-
 import forms.behaviours.DateBehaviours
+import play.api.i18n.Messages
+import play.api.test.Helpers.stubMessages
 
 class $className$FormProviderSpec extends DateBehaviours {
 
-  val form = new $className$FormProvider()()
+  private implicit val messages: Messages = stubMessages()
+  private val form = new $className$FormProvider()()
 
   ".value" - {
 

--- a/src/main/scaffolds/datePage/migrations/$className__snake$.sh
+++ b/src/main/scaffolds/datePage/migrations/$className__snake$.sh
@@ -16,7 +16,7 @@ echo "Adding messages to conf.messages"
 echo "" >> ../conf/messages.en
 echo "$className;format="decap"$.title = $className$" >> ../conf/messages.en
 echo "$className;format="decap"$.heading = $className$" >> ../conf/messages.en
-echo "$className;format="decap"$.hint = For example, 12 11 2007" >> ../conf/messages.en
+echo "$className;format="decap"$.hint = For example, 12 11 2007." >> ../conf/messages.en
 echo "$className;format="decap"$.checkYourAnswersLabel = $className$" >> ../conf/messages.en
 echo "$className;format="decap"$.error.required.all = Enter the $className;format="decap"$" >> ../conf/messages.en
 echo "$className;format="decap"$.error.required.two = The $className;format="decap"$" must include {0} and {1} >> ../conf/messages.en


### PR DESCRIPTION
# Date page improvements

* Allow months to be supplied as names (e.g. January) or abbreviated names (e.g. Jan) on date fields
* Ensure date errors are properly internationalised
* Only highlight the relevant date parts when we know which one(s) are in error
* Ensure timeout dialog is properly internationalised
* Update dependencies
