### PR TITLE
Add DateTimeFormats utility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
+## v0.32.0 - 2023-11-28
+
+### Changed
+* Add DateTimeFormats utility to make internationalising dates easier, and use in DatePage's CYA viewmodel
+
 ## v0.31.0 - 2023-11-21
 
 ### Changed

--- a/src/main/g8/app/utils/DateTimeFormats.scala
+++ b/src/main/g8/app/utils/DateTimeFormats.scala
@@ -1,0 +1,23 @@
+package utils
+
+import play.api.i18n.Lang
+
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+
+object DateTimeFormats {
+
+  private val dateTimeFormatter = DateTimeFormatter.ofPattern("d MMMM yyyy")
+
+  private val localisedDateTimeFormatters = Map(
+    "en" -> dateTimeFormatter,
+    "cy" -> dateTimeFormatter.withLocale(new Locale("cy"))
+  )
+
+  def dateTimeFormat()(implicit lang: Lang): DateTimeFormatter = {
+    localisedDateTimeFormatters.getOrElse(lang.code, dateTimeFormatter)
+  }
+
+  val dateTimeHintFormat: DateTimeFormatter =
+    DateTimeFormatter.ofPattern("d M yyyy")
+}

--- a/src/main/g8/test/utils/DateTimeFormatsSpec.scala
+++ b/src/main/g8/test/utils/DateTimeFormatsSpec.scala
@@ -1,0 +1,32 @@
+package utils
+
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.must.Matchers
+import play.api.i18n.Lang
+import utils.DateTimeFormats.dateTimeFormat
+
+import java.time.LocalDate
+
+class DateTimeFormatsSpec extends AnyFreeSpec with Matchers {
+
+  ".dateTimeFormat" - {
+
+    "must format dates in English" in {
+      val formatter = dateTimeFormat()(Lang("en"))
+      val result = LocalDate.of(2023, 1, 1).format(formatter)
+      result mustEqual "1 January 2023"
+    }
+
+    "must format dates in Welsh" in {
+      val formatter = dateTimeFormat()(Lang("cy"))
+      val result = LocalDate.of(2023, 1, 1).format(formatter)
+      result mustEqual "1 Ionawr 2023"
+    }
+
+    "must default to English format" in {
+      val formatter = dateTimeFormat()(Lang("de"))
+      val result = LocalDate.of(2023, 1, 1).format(formatter)
+      result mustEqual "1 January 2023"
+    }
+  }
+}

--- a/src/main/scaffolds/datePage/app/viewmodels/checkAnswers/$className$Summary.scala
+++ b/src/main/scaffolds/datePage/app/viewmodels/checkAnswers/$className$Summary.scala
@@ -1,12 +1,11 @@
 package viewmodels.checkAnswers
 
-import java.time.format.DateTimeFormatter
-
 import controllers.routes
 import models.{CheckMode, UserAnswers}
 import pages.$className$Page
-import play.api.i18n.Messages
+import play.api.i18n.{Lang, Messages}
 import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
+import utils.DateTimeFormats.dateTimeFormat
 import viewmodels.govuk.summarylist._
 import viewmodels.implicits._
 
@@ -16,11 +15,11 @@ object $className$Summary  {
     answers.get($className$Page).map {
       answer =>
 
-        val dateFormatter = DateTimeFormatter.ofPattern("d MMMM yyyy")
+        implicit val lang: Lang = messages.lang
 
         SummaryListRowViewModel(
           key     = "$className;format="decap"$.checkYourAnswersLabel",
-          value   = ValueViewModel(answer.format(dateFormatter)),
+          value   = ValueViewModel(answer.format(dateTimeFormat())),
           actions = Seq(
             ActionItemViewModel("site.change", routes.$className$Controller.onPageLoad(CheckMode).url)
               .withVisuallyHiddenText(messages("$className;format="decap"$.change.hidden"))


### PR DESCRIPTION
Add DateTimeFormats utility to make internationalising dates easier, and use in DatePage's CYA viewmodel.