### PR TITLE
Change root level logging config and update list of named loggers

### DIFF
--- a/src/main/g8/conf/logback.xml
+++ b/src/main/g8/conf/logback.xml
@@ -55,7 +55,7 @@
 
     <logger name="uk.gov" level="INFO"/>
 
-    <logger name="reactivemongo.core" level="INFO"/>
+    <logger name="org.mongodb" level="INFO"/>
     <logger name="pekko" level="INFO"/>
     <logger name="play" level="INFO"/>
     <logger name="org.jose4j" level="INFO"/>
@@ -75,7 +75,7 @@
         <appender-ref ref="STDOUT"/>
     </logger>
 
-    <root level="DEBUG">
+    <root level="INFO">
         <appender-ref ref="FILE"/>
         <appender-ref ref="STDOUT"/>
     </root>


### PR DESCRIPTION
# Change root level logging config and update list of named loggers

**Maintenance**
(Upstreaming from https://github.com/hmrc/low-earners-anomaly-frontend/commit/93e021a9f30a733218517bf4e87f0a8e70927004)

- Change root level logging to default to INFO for local environments. This does not change behavior for deployed environments.
- Remove named logger for org.reactivemongo.core
- Add named logger for org.mongodb

Fixes: N/A

## Checklist

* [x] I've included appropriate unit tests with any code I've added
* [x] I've tested by creating a new service from my fork, applying any scaffolds I've changed, and checking that all unit tests pass and the service runs as expected
* [x] I've added my code using logical, atomic commits
