### PR TITLE
PLATUI-3222: Fix HmrcHead loaded twice bug

### DIFF
--- a/src/main/g8/app/views/templates/Layout.scala.html
+++ b/src/main/g8/app/views/templates/Layout.scala.html
@@ -8,10 +8,8 @@
 
 @this(
     appConfig: FrontendAppConfig,
-    hmrcHead: HmrcHead,
     hmrcTimeoutDialog: HmrcTimeoutDialog,
     hmrcReportTechnicalIssueHelper: HmrcReportTechnicalIssueHelper,
-    hmrcScripts: HmrcScripts,
     alphaBanner: StandardAlphaBanner,
     hmrcStandardPage: HmrcStandardPage
 )
@@ -20,21 +18,19 @@
 
 @head = {
 
-    @hmrcHead(
-        headBlock = if(timeout) { Some(
-            hmrcTimeoutDialog(TimeoutDialog(
-                timeout             = Some(appConfig.timeout),
-                countdown           = Some(appConfig.countdown),
-                keepAliveUrl        = Some(routes.KeepAliveController.keepAlive().url),
-                keepAliveButtonText = Some(messages("timeout.keepAlive")),
-                signOutUrl          = Some(controllers.auth.routes.AuthController.signOut().url),
-                signOutButtonText   = Some(messages("timeout.signOut")),
-                title               = Some(messages("timeout.title")),
-                message             = Some(messages("timeout.message")),
-                language            = Some(messages.lang.code)
-            )))
-        } else None
-    )
+    @if(timeout) {
+        @hmrcTimeoutDialog(TimeoutDialog(
+            timeout             = Some(appConfig.timeout),
+            countdown           = Some(appConfig.countdown),
+            keepAliveUrl        = Some(routes.KeepAliveController.keepAlive().url),
+            keepAliveButtonText = Some(messages("timeout.keepAlive")),
+            signOutUrl          = Some(controllers.auth.routes.AuthController.signOut().url),
+            signOutButtonText   = Some(messages("timeout.signOut")),
+            title               = Some(messages("timeout.title")),
+            message             = Some(messages("timeout.message")),
+            language            = Some(messages.lang.code)
+        ))
+    }
 }
 
 @content = {


### PR DESCRIPTION
# Fix `HmrcHead` loaded twice bug

**Bug fix**
PR #132 introduced bug where the `HmrcHead` was being loaded twice if the was `timeout` parameter was being set to `true`. This has been fixed in this PR.

## Checklist

* [/] I've included appropriate unit tests with any code I've added
* [/] I've tested by creating a new service from my fork, applying any scaffolds I've changed, and checking that all unit tests pass and the service runs as expected
* [/] I've added my code using logical, atomic commits
