### PR TITLE
PLATUI-3398: Replaced deprecated sbt-sassify with new MDTP plugin sbt…

### DIFF
--- a/src/main/g8/app/assets/stylesheets/application.scss
+++ b/src/main/g8/app/assets/stylesheets/application.scss
@@ -1,3 +1,8 @@
+/*
+    Styling in this and other .scss files will be compiled by the sbt-sass-compiler plugin: https://github.com/hmrc/sbt-sass-compiler
+    If you encounter any issue with Sass compilation using the plugin, please reach out to the PlatUI team.
+ */
+
 .js-visible {
   display: none !important;
 }

--- a/src/main/g8/project/AppDependencies.scala
+++ b/src/main/g8/project/AppDependencies.scala
@@ -7,7 +7,7 @@ object AppDependencies {
 
   val compile = Seq(
     play.sbt.PlayImport.ws,
-    "uk.gov.hmrc"       %% "play-frontend-hmrc-play-30"    % "10.10.0",
+    "uk.gov.hmrc"       %% "play-frontend-hmrc-play-30"    % "11.11.0",
     "uk.gov.hmrc"       %% "bootstrap-frontend-play-30"    % bootstrapVersion,
     "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-30"            % hmrcMongoVersion
   )

--- a/src/main/g8/project/plugins.sbt
+++ b/src/main/g8/project/plugins.sbt
@@ -14,7 +14,7 @@ addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0" exclude("org.
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.9")
 
-addSbtPlugin("io.github.irundaia" % "sbt-sassify" % "1.5.2")
+addSbtPlugin("uk.gov.hmrc" % "sbt-sass-compiler" % "0.9.0")
 
 addSbtPlugin("net.ground5hark.sbt" % "sbt-concat" % "0.2.0")
 


### PR DESCRIPTION
…-sass-compiler

# Replace deprecated sbt-sassify with new MDTP plugin sbt-sass-compiler

**New feature** 

sbt-sassify is using a deprecated implementation of Sass. The sbt-sassify maintainers started but appear to have abandoned a branch to change their Sass implementation. PlatUI have therefore created their own plugin to use Dart Sass for Sass compilation in Scala / Play Framework projects (new sbt task that also triggers when the "Assets" pipeline runs)s.

Fixes #PLATUI-3398

## Checklist

* [x] I've included appropriate unit tests with any code I've added
* [x] I've tested by creating a new service from my fork, applying any scaffolds I've changed, and checking that all unit tests pass and the service runs as expected
* [x] I've added my code using logical, atomic commits
