### PR TITLE
upgrade play-frontend-hmrc-play to allow for new branding

### DIFF
--- a/src/main/g8/conf/application.conf
+++ b/src/main/g8/conf/application.conf
@@ -67,6 +67,11 @@ tracking-consent-frontend {
   gtm.container = "transitional"
 }
 
+play-frontend-hmrc {
+    useRebrand = false
+}
+
+
 features {
   welsh-translation: true
 }

--- a/src/main/g8/project/AppDependencies.scala
+++ b/src/main/g8/project/AppDependencies.scala
@@ -7,7 +7,7 @@ object AppDependencies {
 
   val compile = Seq(
     play.sbt.PlayImport.ws,
-    "uk.gov.hmrc"       %% "play-frontend-hmrc-play-30"    % "12.0.0",
+    "uk.gov.hmrc"       %% "play-frontend-hmrc-play-30"    % "12.3.0",
     "uk.gov.hmrc"       %% "bootstrap-frontend-play-30"    % bootstrapVersion,
     "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-30"            % hmrcMongoVersion
   )


### PR DESCRIPTION
Update the play-frontend-hmrc dependency to make the new branding available

Also added the config key to control the feature toggle and set it to be false by default
