### PR TITLE
Update scoverage version to fix issues post-scala 3 upgrade

### DIFF
--- a/src/main/g8/project/plugins.sbt
+++ b/src/main/g8/project/plugins.sbt
@@ -12,9 +12,9 @@ addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.6")
 
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0" exclude("org.scala-lang.modules", "scala-xml_2.12"))
 
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.9")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.2.2")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-sass-compiler" % "0.9.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-sass-compiler" % "0.11.0")
 
 addSbtPlugin("net.ground5hark.sbt" % "sbt-concat" % "0.2.0")
 


### PR DESCRIPTION
- updated scoverage version which fixes issues around excluded files post-scala 3 upgrade.
- updated sass-compiler version to also prevent build issues.