### PR TITLE
Updated repo test to use new MDCExecutionContext to ensure consistency in tests

### DIFF
--- a/src/main/g8/app/repositories/SessionRepository.scala
+++ b/src/main/g8/app/repositories/SessionRepository.scala
@@ -9,7 +9,7 @@ import play.api.libs.json.Format
 import uk.gov.hmrc.mongo.MongoComponent
 import uk.gov.hmrc.mongo.play.json.PlayMongoRepository
 import uk.gov.hmrc.mongo.play.json.formats.MongoJavatimeFormats
-import uk.gov.hmrc.play.http.logging.Mdc
+import uk.gov.hmrc.mdc.Mdc
 
 import java.time.{Clock, Instant}
 import java.util.concurrent.TimeUnit

--- a/src/main/g8/project/AppDependencies.scala
+++ b/src/main/g8/project/AppDependencies.scala
@@ -2,15 +2,14 @@ import sbt._
 
 object AppDependencies {
 
-  private val bootstrapVersion = "9.13.0"
-  private val hmrcMongoVersion = "2.6.0"
+  private val bootstrapVersion = "10.1.0"
+  private val hmrcMongoVersion = "2.7.0"
 
   val compile = Seq(
     play.sbt.PlayImport.ws,
-    "uk.gov.hmrc"       %% "play-frontend-hmrc-play-30"    % "12.3.0",
+    "uk.gov.hmrc"       %% "play-frontend-hmrc-play-30"    % "12.8.0",
     "uk.gov.hmrc"       %% "bootstrap-frontend-play-30"    % bootstrapVersion,
-    "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-30"            % hmrcMongoVersion,
-    "uk.gov.hmrc"       %% "mdc"                           % "0.2.0"
+    "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-30"            % hmrcMongoVersion
 
   )
 


### PR DESCRIPTION
Repo tests were intermittently failing when checking MDC persistence after mongo calls.

The new HMRC MDC library has introduced a new MDCExecutionContext to allow tests to mimic the execution context that is injected by bootstrap. This ensures that we are testing our functionality's use of Mdc.preservingMdc() rather than sometimes intermittently failing in a way that won't in production.

The mustPreserveMdc test will now fail 100% of the time where Mdc.preservingMdc is missing and we're using headOption on a mongo call. And it will now pass where Mdc.preservingMdc is present.